### PR TITLE
fix: three correctness bugs in value handling and keyboard copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Wrapped with Mantine layout primitives like Paper, Stack, and SimpleGrid, JsonTr
 - **Paper wrapper** with `withBorder` for bordered container look
 - **Custom root name** via `rootName` prop
 - Syntax highlighting with customizable colors for 16+ data types (strings, numbers, booleans, null, Date, RegExp, Map, Set, BigInt, Symbol, React elements, etc.)
+- Safe on object graphs: circular references are marked `[Circular]` instead of crashing, while
+  shared non-circular references still expand everywhere they appear
 - Dark mode support with automatic color adaptation
 - Copy-to-clipboard on individual nodes + global copy all JSON
 - Keyboard navigation (arrow keys, Space to expand, Ctrl+C to copy)

--- a/docs/demos/JsonTree.demo.circular.tsx
+++ b/docs/demos/JsonTree.demo.circular.tsx
@@ -1,0 +1,77 @@
+import { JsonTree } from '@gfazioli/mantine-json-tree';
+import { Paper } from '@mantine/core';
+import { MantineDemo } from '@mantinex/demo';
+
+const code = `
+import { JsonTree } from "@gfazioli/mantine-json-tree";
+import { Paper } from '@mantine/core';
+
+function Demo() {
+  // A node graph: every child points back at its parent, and a shared
+  // "config" object is referenced from two different branches.
+  const config = { theme: 'dark', locale: 'en' };
+
+  const root: any = {
+    id: 'root',
+    config,
+    child: {
+      id: 'child',
+      config,
+    },
+  };
+
+  root.self = root;
+  root.child.parent = root;
+
+  return (
+    <Paper withBorder>
+      <JsonTree
+        data={root}
+        title="graph.json"
+        defaultExpanded
+        maxDepth={-1}
+        withExpandAll
+        showItemsCount
+      />
+    </Paper>
+  );
+}
+`;
+
+function Demo() {
+  // A node graph: every child points back at its parent, and a shared
+  // "config" object is referenced from two different branches.
+  const config = { theme: 'dark', locale: 'en' };
+
+  const root: any = {
+    id: 'root',
+    config,
+    child: {
+      id: 'child',
+      config,
+    },
+  };
+
+  root.self = root;
+  root.child.parent = root;
+
+  return (
+    <Paper withBorder>
+      <JsonTree
+        data={root}
+        title="graph.json"
+        defaultExpanded
+        maxDepth={-1}
+        withExpandAll
+        showItemsCount
+      />
+    </Paper>
+  );
+}
+
+export const circular: MantineDemo = {
+  type: 'code',
+  component: Demo,
+  code,
+  defaultExpanded: false,
+};

--- a/docs/demos/index.ts
+++ b/docs/demos/index.ts
@@ -1,4 +1,5 @@
 export { callbacks } from './JsonTree.demo.callbacks';
+export { circular } from './JsonTree.demo.circular';
 export { configurator } from './JsonTree.demo.configurator';
 export { customIcons } from './JsonTree.demo.customIcons';
 export { functions } from './JsonTree.demo.functions';

--- a/docs/docs.mdx
+++ b/docs/docs.mdx
@@ -16,6 +16,7 @@ import * as demos from './demos';
 - Controlled expand/collapse state (`expanded`, `onExpandedChange`)
 - `onExpand` and `onCollapse` callbacks for individual node toggling
 - Keyboard copy: `Ctrl+C` / `Cmd+C` copies the focused node when `withCopyToClipboard` is enabled
+- **Circular references** are detected and marked instead of crashing the component
 - Responsive `size` prop via Mantine breakpoint objects (CSS-native, no re-renders)
 
 ## Installation
@@ -103,9 +104,26 @@ Below is an example of syntax highlighting for different JSON value types: strin
 - **Set**: Unique value collections that are expandable to show their elements
 - **React Elements**: React components displayed with their component name (e.g., `<Loader />`)
 
+React elements are recognised by their internal `$$typeof` marker, so ordinary data is never
+mistaken for one. An object such as `{ type: 'text', props: { label: 'Name' } }` — a common
+shape in form-builder and low-code JSON — is rendered as a regular, expandable object.
+
 All colors can be customized using CSS variables for each type.
 
 <Demo data={demos.specialTypes} />
+
+## Circular References
+
+Object graphs that point back at themselves are everywhere in real debugging sessions — a child
+holding a reference to its parent, a linked list, a cached entity pointing at the store that owns
+it. `JsonTree` walks the current branch and stops as soon as a value reappears on its own ancestor
+chain, rendering it as `[Circular]` rather than recursing until the stack overflows.
+
+Only the ancestor chain is tracked, never every value already visited. A value referenced from two
+different branches is shared, not circular, so it keeps expanding normally in both places — as the
+`config` object does below.
+
+<Demo data={demos.circular} />
 
 ## Indent Guides
 
@@ -157,7 +175,9 @@ Use the `onNodeClick` callback to handle clicks on any node in the tree, and the
 - **Arrow Right**: Expand a collapsed node or move to first child
 - **Arrow Left**: Collapse an expanded node or move to parent
 - **Space**: Toggle node expansion
-- **Ctrl+C / Cmd+C**: Copy the focused node's value to clipboard (when `withCopyToClipboard` is enabled)
+- **Ctrl+C / Cmd+C**: Copy the focused node's value to clipboard (when `withCopyToClipboard` is
+  enabled). With no node focused it falls back to the root, and it never intercepts the shortcut
+  while a form control inside the component — such as the search input — holds focus.
 
 ## Path Tooltip
 

--- a/docs/styles-api/JsonTree.styles-api.ts
+++ b/docs/styles-api/JsonTree.styles-api.ts
@@ -54,6 +54,7 @@ export const JsonTreeStylesApi: StylesApiData<JsonTreeFactory> = {
       '--json-tree-color-regexp': 'Color for RegExp values',
       '--json-tree-color-map': 'Color for Map collection values',
       '--json-tree-color-set': 'Color for Set collection values',
+      '--json-tree-color-circular': 'Color for circular reference markers',
     },
     bracket: {
       '--json-tree-color-bracket': 'Color for brackets and punctuation',

--- a/package/src/JsonTree.module.css
+++ b/package/src/JsonTree.module.css
@@ -109,6 +109,11 @@
     color: var(--json-tree-color-map);
     font-weight: 600;
   }
+
+  &[data-type='circular'] {
+    color: var(--json-tree-color-circular);
+    font-style: italic;
+  }
 }
 
 .bracket {

--- a/package/src/JsonTree.test.tsx
+++ b/package/src/JsonTree.test.tsx
@@ -1,6 +1,6 @@
 import { render } from '@mantine-tests/core';
 import { Loader } from '@mantine/core';
-import { fireEvent } from '@testing-library/react';
+import { fireEvent, waitFor } from '@testing-library/react';
 import React from 'react';
 import { JsonTree } from './JsonTree';
 
@@ -508,6 +508,130 @@ describe('JsonTree', () => {
       const treeData = [convertToTreeData({ Name: 'ALICE' }, 'root', 'root', 0)];
       const result = searchTree(treeData, 'alice');
       expect(result.directMatches.size).toBeGreaterThan(0);
+    });
+  });
+  describe('keyboard copy targeting', () => {
+    const mockClipboard = () => {
+      const writeText = jest.fn().mockResolvedValue(undefined);
+      Object.defineProperty(navigator, 'clipboard', {
+        value: { writeText },
+        configurable: true,
+        writable: true,
+      });
+      return writeText;
+    };
+
+    it('copies the focused node, not the root', async () => {
+      const writeText = mockClipboard();
+      const { container } = render(
+        <JsonTree
+          data={{ alpha: { nested: 'AAA' }, beta: 'BBB' }}
+          defaultExpanded
+          maxDepth={-1}
+          withCopyToClipboard
+        />
+      );
+
+      const row = container.querySelector<HTMLElement>(
+        'li[role="treeitem"][data-value="root.beta"]'
+      )!;
+      row.focus();
+      fireEvent.keyDown(row, { key: 'c', metaKey: true });
+
+      await waitFor(() => expect(writeText).toHaveBeenCalled());
+      expect(writeText.mock.calls[0][0]).toBe('"BBB"');
+    });
+
+    it('falls back to the root node when nothing inside the tree has focus', async () => {
+      const writeText = mockClipboard();
+      const { container } = render(
+        <JsonTree data={{ beta: 'BBB' }} defaultExpanded maxDepth={-1} withCopyToClipboard />
+      );
+
+      const root = container.querySelector<HTMLElement>('li[role="treeitem"][data-value="root"]')!;
+      fireEvent.keyDown(root, { key: 'c', metaKey: true });
+
+      await waitFor(() => expect(writeText).toHaveBeenCalled());
+      expect(JSON.parse(writeText.mock.calls[0][0])).toEqual({ beta: 'BBB' });
+    });
+
+    it('does not hijack copy from a form control inside the component', async () => {
+      const writeText = mockClipboard();
+      const { container } = render(
+        <JsonTree data={{ a: 1 }} title="Test" withSearch withCopyToClipboard />
+      );
+      fireEvent.click(container.querySelector('.mantine-ActionIcon-root')!);
+
+      const input = container.querySelector<HTMLElement>('input[placeholder]')!;
+      fireEvent.keyDown(input, { key: 'c', metaKey: true });
+
+      await Promise.resolve();
+      expect(writeText).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('React element detection', () => {
+    it('treats a plain object carrying type and props as data, not an element', () => {
+      const { container } = render(
+        <JsonTree
+          data={{ field: { type: 'text', props: { label: 'Name' } } }}
+          defaultExpanded
+          maxDepth={-1}
+        />
+      );
+
+      // The subtree must be reachable, not collapsed into `<Component />`
+      expect(container.querySelector('[data-value="root.field.type"]')).toBeTruthy();
+      expect(container.querySelector('[data-value="root.field.props.label"]')).toBeTruthy();
+      expect(container.querySelector('[data-type="react-element"]')).toBeFalsy();
+    });
+
+    it('still detects real React elements', () => {
+      const { container } = render(
+        <JsonTree data={{ el: <Loader /> }} defaultExpanded maxDepth={-1} />
+      );
+      expect(container.querySelector('[data-type="react-element"]')).toBeTruthy();
+    });
+  });
+
+  describe('circular references', () => {
+    it('renders a marker instead of overflowing the stack', () => {
+      const data: any = { name: 'node' };
+      data.self = data;
+
+      const { container } = render(<JsonTree data={data} defaultExpanded maxDepth={-1} />);
+
+      const marker = container.querySelector('[data-type="circular"]');
+      expect(marker).toBeTruthy();
+      expect(marker?.textContent).toBe('[Circular]');
+    });
+
+    it('detects a cycle nested deeper than the root', () => {
+      const parent: any = { id: 1, child: { id: 2 } };
+      parent.child.parent = parent;
+
+      const { container } = render(<JsonTree data={parent} defaultExpanded maxDepth={-1} />);
+      expect(container.querySelector('[data-value="root.child.parent"]')).toBeTruthy();
+      expect(container.querySelector('[data-type="circular"]')).toBeTruthy();
+    });
+
+    it('expands a shared reference in every branch that holds it', () => {
+      const shared = { flag: true };
+      const { container } = render(
+        <JsonTree data={{ left: shared, right: shared }} defaultExpanded maxDepth={-1} />
+      );
+
+      // Shared but acyclic: both branches must expand, neither is a cycle
+      expect(container.querySelector('[data-value="root.left.flag"]')).toBeTruthy();
+      expect(container.querySelector('[data-value="root.right.flag"]')).toBeTruthy();
+      expect(container.querySelector('[data-type="circular"]')).toBeFalsy();
+    });
+
+    it('survives a cycle through an array', () => {
+      const arr: any[] = [1];
+      arr.push(arr);
+      const { container } = render(<JsonTree data={{ arr }} defaultExpanded maxDepth={-1} />);
+      expect(container.querySelector('[data-type="circular"]')).toBeTruthy();
     });
   });
 });

--- a/package/src/JsonTree.test.tsx
+++ b/package/src/JsonTree.test.tsx
@@ -634,4 +634,80 @@ describe('JsonTree', () => {
       expect(container.querySelector('[data-type="circular"]')).toBeTruthy();
     });
   });
+  describe('clipboard serialization', () => {
+    const { stringifyValue } = require('./lib/utils');
+
+    it('keeps JSON-representable values exactly as JSON.stringify would', () => {
+      expect(stringifyValue({ a: 1 })).toBe(JSON.stringify({ a: 1 }, null, 2));
+      expect(stringifyValue([1, 'two'])).toBe(JSON.stringify([1, 'two'], null, 2));
+      expect(stringifyValue('he said "hi"')).toBe('"he said \\"hi\\""');
+      expect(stringifyValue(null)).toBe('null');
+      expect(stringifyValue(42)).toBe('42');
+    });
+
+    it('falls back to the rendered form for values JSON drops', () => {
+      // JSON.stringify returns undefined for these, which used to put the
+      // literal text "undefined" on the clipboard for every one of them
+      expect(stringifyValue(function handleClick() {})).toBe('[Function: handleClick]');
+      expect(stringifyValue(Symbol.for('app.config'))).toBe('Symbol(app.config)');
+      expect(stringifyValue(undefined)).toBe('undefined');
+    });
+
+    it('serializes BigInt instead of throwing', () => {
+      // JSON.stringify throws a TypeError on BigInt, which the copy handlers
+      // swallowed as a silent no-op
+      expect(stringifyValue(BigInt(123))).toBe('123n');
+      expect(stringifyValue({ id: BigInt(9007199254740991) })).toContain('"9007199254740991n"');
+    });
+
+    it('marks cycles instead of throwing', () => {
+      const node: any = { name: 'node' };
+      node.self = node;
+      const out = stringifyValue(node);
+      expect(out).toContain('"name": "node"');
+      expect(out).toContain('"self": "[Circular]"');
+    });
+
+    it('marks a cycle nested below the root', () => {
+      const parent: any = { id: 1, child: { id: 2 } };
+      parent.child.parent = parent;
+      const out = JSON.parse(stringifyValue(parent));
+      expect(out).toEqual({ id: 1, child: { id: 2, parent: '[Circular]' } });
+    });
+
+    it('serializes a shared reference in full on both sides', () => {
+      const shared = { flag: true };
+      const out = JSON.parse(stringifyValue({ left: shared, right: shared }));
+      // shared but acyclic: neither side may collapse to a marker
+      expect(out).toEqual({ left: { flag: true }, right: { flag: true } });
+    });
+
+    it('survives a cycle through an array', () => {
+      const arr: unknown[] = [1];
+      arr.push(arr);
+      expect(JSON.parse(stringifyValue(arr))).toEqual([1, '[Circular]']);
+    });
+
+    it('copies a node holding a cycle instead of doing nothing', async () => {
+      const writeText = jest.fn().mockResolvedValue(undefined);
+      Object.defineProperty(navigator, 'clipboard', {
+        value: { writeText },
+        configurable: true,
+        writable: true,
+      });
+
+      const data: any = { id: 'root' };
+      data.self = data;
+
+      const { container } = render(
+        <JsonTree data={data} defaultExpanded maxDepth={-1} withCopyToClipboard />
+      );
+      const row = container.querySelector<HTMLElement>('li[role="treeitem"][data-value="root"]')!;
+      row.focus();
+      fireEvent.keyDown(row, { key: 'c', metaKey: true });
+
+      await waitFor(() => expect(writeText).toHaveBeenCalled());
+      expect(writeText.mock.calls[0][0]).toContain('"self": "[Circular]"');
+    });
+  });
 });

--- a/package/src/JsonTree.tsx
+++ b/package/src/JsonTree.tsx
@@ -49,6 +49,7 @@ import {
   getItemCount,
   isExpandable,
   searchTree,
+  stringifyValue,
   type JSONTreeNodeData,
   type ValueType,
 } from './lib/utils';
@@ -435,7 +436,7 @@ function renderJSONNode(
   const handleCopy = async (e: React.MouseEvent): Promise<boolean> => {
     e.stopPropagation();
     try {
-      const copy = JSON.stringify(value, null, 2);
+      const copy = stringifyValue(value);
       await navigator.clipboard.writeText(copy);
       onCopy?.(copy, value);
       return true;
@@ -887,13 +888,12 @@ export const JsonTree = factory<JsonTreeFactory>((_props) => {
       }
 
       e.preventDefault();
+      const copy = stringifyValue(nodeData.nodeData.value);
       try {
-        const copy = JSON.stringify(nodeData.nodeData.value, null, 2);
         await navigator.clipboard.writeText(copy);
         onCopy?.(copy, nodeData.nodeData.value);
       } catch {
-        // Clipboard write may fail silently in unsupported contexts, and
-        // JSON.stringify throws on circular data
+        // Clipboard write may fail silently in unsupported contexts
       }
     },
     [withCopyToClipboard, treeData, onCopy]
@@ -985,8 +985,8 @@ export const JsonTree = factory<JsonTreeFactory>((_props) => {
   // Global copy handler with visual feedback
   const [copiedAll, setCopiedAll] = useState(false);
   const handleCopyAll = useCallback(async () => {
+    const json = stringifyValue(data);
     try {
-      const json = JSON.stringify(data, null, 2);
       await navigator.clipboard.writeText(json);
       onCopyAll?.(json);
       onCopy?.(json, data);

--- a/package/src/JsonTree.tsx
+++ b/package/src/JsonTree.tsx
@@ -95,7 +95,8 @@ export type JsonTreeCssVariables = {
     | '--json-tree-color-symbol'
     | '--json-tree-color-regexp'
     | '--json-tree-color-map'
-    | '--json-tree-color-set';
+    | '--json-tree-color-set'
+    | '--json-tree-color-circular';
   bracket: '--json-tree-color-bracket';
   indentGuide:
     | '--json-tree-indent-guide-color-0'
@@ -688,6 +689,7 @@ const varsResolver = createVarsResolver<JsonTreeFactory>(
         '--json-tree-color-regexp': 'var(--mantine-color-lime-7)',
         '--json-tree-color-map': 'var(--mantine-color-grape-7)',
         '--json-tree-color-set': 'var(--mantine-color-grape-7)',
+        '--json-tree-color-circular': 'var(--mantine-color-red-6)',
       },
       bracket: { '--json-tree-color-bracket': 'var(--mantine-color-gray-5)' },
       indentGuide: {
@@ -845,26 +847,53 @@ export const JsonTree = factory<JsonTreeFactory>((_props) => {
   // Keyboard handler for Ctrl+C copy on focused node
   const handleKeyDown = useCallback(
     async (e: React.KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.key === 'c' && withCopyToClipboard) {
-        e.preventDefault();
-        const focused = (e.currentTarget as HTMLElement).querySelector(
-          '[data-value][tabindex="0"], [data-value]:focus'
-        );
-        if (focused) {
-          const nodePath = focused.getAttribute('data-value');
-          if (nodePath) {
-            const nodeData = findNodeByPath(treeData, nodePath);
-            if (nodeData?.nodeData) {
-              try {
-                const copy = JSON.stringify(nodeData.nodeData.value, null, 2);
-                await navigator.clipboard.writeText(copy);
-                onCopy?.(copy, nodeData.nodeData.value);
-              } catch {
-                // Clipboard write may fail silently in unsupported contexts
-              }
-            }
-          }
-        }
+      if (!withCopyToClipboard || !(e.metaKey || e.ctrlKey) || e.key !== 'c') {
+        return;
+      }
+
+      // Never hijack the native copy of a selection made inside a form control
+      // rendered within the tree (the search input, a custom `title`, …).
+      const target = e.target as HTMLElement | null;
+      if (
+        target?.closest?.(
+          'input, textarea, select, [contenteditable]:not([contenteditable="false"])'
+        )
+      ) {
+        return;
+      }
+
+      // Resolve the row that actually holds focus. Matching `[tabindex="0"]`
+      // could only ever find the root: Mantine's Tree gives the root node
+      // tabindex 0 and every other node -1, and `querySelector` resolves in
+      // document order — so the root won over the focused node every time.
+      // Scoping to `[role="treeitem"]` also keeps the value cells out of the
+      // match, since those carry a `data-value` holding the formatted value
+      // rather than a node path.
+      const root = e.currentTarget as HTMLElement;
+      const active = document.activeElement as HTMLElement | null;
+      const focused =
+        (active && root.contains(active)
+          ? active.closest('[role="treeitem"][data-value]')
+          : null) ?? root.querySelector('[role="treeitem"][data-value]');
+
+      const nodePath = focused?.getAttribute('data-value');
+      if (!nodePath) {
+        return;
+      }
+
+      const nodeData = findNodeByPath(treeData, nodePath);
+      if (!nodeData?.nodeData) {
+        return;
+      }
+
+      e.preventDefault();
+      try {
+        const copy = JSON.stringify(nodeData.nodeData.value, null, 2);
+        await navigator.clipboard.writeText(copy);
+        onCopy?.(copy, nodeData.nodeData.value);
+      } catch {
+        // Clipboard write may fail silently in unsupported contexts, and
+        // JSON.stringify throws on circular data
       }
     },
     [withCopyToClipboard, treeData, onCopy]

--- a/package/src/lib/utils.tsx
+++ b/package/src/lib/utils.tsx
@@ -46,7 +46,7 @@ export type ValueType =
  * everyday shape in form-builder and low-code JSON, and treating it as an
  * element hides the whole subtree behind `<Component />`.
  */
-function isReactElement(value: any): boolean {
+function isReactElement(value: unknown): boolean {
   if (typeof value !== 'object' || value === null) {
     return false;
   }
@@ -179,6 +179,80 @@ export function formatValue(value: any, type: ValueType): string {
     return '[Circular]';
   }
   return String(value);
+}
+
+/**
+ * Values JSON cannot express, rendered the way the tree shows them. Returns
+ * `undefined` when JSON is able to represent the value on its own.
+ */
+function formatNonJsonValue(value: unknown): string | undefined {
+  const type = getValueType(value);
+  if (type === 'undefined' || type === 'function' || type === 'symbol' || type === 'bigint') {
+    return formatValue(value, type);
+  }
+  return undefined;
+}
+
+/**
+ * A `JSON.stringify` replacer that swaps reference cycles for the same
+ * `[Circular]` marker the tree renders, and non-JSON leaves for their displayed
+ * form. It follows the ancestor chain rather than a set of everything already
+ * seen, so a value referenced from two sibling branches — shared, not circular —
+ * is still serialized in full on both sides, exactly as the tree expands it.
+ */
+function createCycleSafeReplacer() {
+  const ancestors: unknown[] = [];
+
+  return function replacer(this: unknown, _key: string, value: unknown): unknown {
+    const nonJson = formatNonJsonValue(value);
+    if (nonJson !== undefined) {
+      return nonJson;
+    }
+
+    if (isReferenceType(value)) {
+      // `this` is the holder the value was read from: unwind the chain back to
+      // it before testing, so only real ancestors count.
+      const index = ancestors.indexOf(this);
+      if (index === -1) {
+        ancestors.push(this);
+      } else {
+        ancestors.length = index + 1;
+      }
+      if (ancestors.includes(value)) {
+        return '[Circular]';
+      }
+    }
+
+    return value;
+  };
+}
+
+/**
+ * Serialize a value for the clipboard the way the tree displays it.
+ *
+ * `JSON.stringify` alone does not cover what the tree can render: it returns
+ * `undefined` for `undefined`, functions and symbols — which would put the
+ * literal text "undefined" on the clipboard — and it throws on BigInt and on
+ * anything holding a reference cycle, which the copy handlers swallowed as a
+ * silent no-op. Both cases now fall back to the rendered form, so what lands on
+ * the clipboard matches what is on screen.
+ */
+export function stringifyValue(value: unknown): string {
+  const direct = formatNonJsonValue(value);
+  if (direct !== undefined) {
+    return direct;
+  }
+
+  try {
+    const json = JSON.stringify(value, createCycleSafeReplacer(), 2);
+    if (json !== undefined) {
+      return json;
+    }
+  } catch {
+    // Values JSON refuses outright fall through to the rendered form below
+  }
+
+  return formatValue(value, getValueType(value));
 }
 
 /**

--- a/package/src/lib/utils.tsx
+++ b/package/src/lib/utils.tsx
@@ -32,19 +32,33 @@ export type ValueType =
   | 'symbol'
   | 'regexp'
   | 'map'
-  | 'set';
+  | 'set'
+  | 'circular';
 
 /**
  * Check if a value is a React element.
+ *
+ * Detection relies on the `$$typeof` marker alone. React stamps every element
+ * with a symbol from the global registry (`react.element`,
+ * `react.transitional.element`, …), so matching the `react.` prefix also covers
+ * renderer variants without enumerating them. A structural `type` + `props`
+ * check would misread ordinary data: `{ type: 'text', props: { … } }` is an
+ * everyday shape in form-builder and low-code JSON, and treating it as an
+ * element hides the whole subtree behind `<Component />`.
  */
 function isReactElement(value: any): boolean {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    (value.$$typeof === Symbol.for('react.element') ||
-      value.$$typeof === Symbol.for('react.transitional.element') ||
-      (typeof value.type !== 'undefined' && typeof value.props !== 'undefined'))
-  );
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const marker = (value as { $$typeof?: unknown }).$$typeof;
+  return typeof marker === 'symbol' && (marker.description ?? '').startsWith('react.');
+}
+
+/**
+ * Check whether a value can take part in a reference cycle.
+ */
+function isReferenceType(value: unknown): boolean {
+  return (typeof value === 'object' && value !== null) || typeof value === 'function';
 }
 
 /**
@@ -161,6 +175,9 @@ export function formatValue(value: any, type: ValueType): string {
   if (type === 'set') {
     return `Set(${value.size})`;
   }
+  if (type === 'circular') {
+    return '[Circular]';
+  }
   return String(value);
 }
 
@@ -188,9 +205,23 @@ export function convertToTreeData(
   key?: string,
   path: string = 'root',
   depth: number = 0,
-  displayFunctions: JsonTreeFunctionDisplay = 'as-string'
+  displayFunctions: JsonTreeFunctionDisplay = 'as-string',
+  ancestors: readonly unknown[] = []
 ): JSONTreeNodeData {
   const type = getValueType(value);
+
+  // Guard against reference cycles, which would otherwise recurse until the
+  // stack blows (`obj.self = obj` is routine in debug panels and object graphs).
+  // Only the current ancestor chain is tracked, never every value already seen,
+  // so a value referenced twice in sibling branches — shared but not circular —
+  // still expands normally in both places.
+  if (isReferenceType(value) && ancestors.includes(value)) {
+    return {
+      value: path,
+      label: key ?? path,
+      nodeData: { type: 'circular', value, key, path, depth },
+    };
+  }
 
   // Handle React elements as primitive values to avoid circular reference issues
   if (type === 'react-element') {
@@ -239,7 +270,10 @@ export function convertToTreeData(
       },
       {} as Record<string, any>
     );
-    return convertToTreeData(functionProps, key, path, depth, displayFunctions);
+    return convertToTreeData(functionProps, key, path, depth, displayFunctions, [
+      ...ancestors,
+      value,
+    ]);
   }
 
   const expandable = isExpandable(value);
@@ -268,8 +302,11 @@ export function convertToTreeData(
     entries = Object.entries(value);
   }
 
+  const childAncestors = [...ancestors, value];
   const children = entries
-    .map(([k, v]) => convertToTreeData(v, k, `${path}.${k}`, depth + 1, displayFunctions))
+    .map(([k, v]) =>
+      convertToTreeData(v, k, `${path}.${k}`, depth + 1, displayFunctions, childAncestors)
+    )
     .filter((node) => node !== null); // Filter out hidden functions
 
   return {


### PR DESCRIPTION
Found while auditing the component for #22 (editable mode). All three bugs are pre-existing and independent of that feature, but an editor would have inherited every one of them, so they land first.

Related to #22 — this does **not** implement editable mode.

## 1. Circular references crashed the component

`convertToTreeData` recursed with no cycle detection, so `obj.self = obj` — routine in debug panels, parent/child graphs and cached entities — blew the stack. And it did not just break the tree: a single cycle anywhere in the data took down the whole page.

Reproduced on the docs site with the pre-fix build:

```
Runtime RangeError: Maximum call stack size exceeded
  convertToTreeData → Array.map → convertToTreeData → …  (50 frames)
```

The walker now carries its own ancestor chain and renders a repeat as `[Circular]`.

Only the chain is tracked, never every value already visited. A value referenced from two sibling branches is *shared*, not circular, and must keep expanding in both places — a global seen-set would have silently collapsed it. There is a test pinning exactly that.

## 2. Plain data was read as React elements

`isReactElement` fell back to a structural `type` + `props` check, so this:

```json
{ "field": { "type": "text", "props": { "label": "Full name", "required": true } } }
```

collapsed into `<Component />` and took its whole subtree with it — unreachable, uncopyable, invisible. That shape is an everyday one in form-builder and low-code JSON, which is one of the use cases #22 is about.

Detection is now the `$$typeof` marker alone, matched on its `react.` prefix so renderer variants stay covered. Real elements are unaffected (`<Loader />`, `<button />`, `<div />` all still render as elements — there is a test).

This change depends on the one above: the loose check was also what accidentally stopped such objects from recursing, so narrowing it without a cycle guard would have turned a wrong render into a crash.

## 3. Ctrl+C copied the root instead of the focused node

The selector `[data-value][tabindex="0"], [data-value]:focus` could only ever resolve to the root — Mantine's Tree gives the root `tabindex="0"` and every other node `-1`, and `querySelector` matches in document order, so the root won before `:focus` was ever considered.

Verified in the browser, identical sequence both ways (focus the root, nine real ArrowDown presses to `root.field`, then Cmd+C):

| | clipboard receives |
|---|---|
| before | the entire root object — 9 top-level keys |
| after | `{ "type": "text", "props": { … } }` — the focused node |

The handler now reads `document.activeElement`, scopes to `[role="treeitem"]` so value cells cannot match (their `data-value` holds the formatted value, not a path), and keeps the root as the fallback when nothing has focus.

It also no longer `preventDefault`s the shortcut while a form control inside the component holds focus. The search input needs that today — selecting text in it and pressing Cmd+C used to copy the JSON root instead — and an inline editor will need it next.

## Verification

- **Nine regression tests**, each verified to fail against the old source (the circular ones with `RangeError`). Three pass either way *by design*, pinning behaviour that must not change: shared references keep expanding, real React elements stay detected, the root stays the no-focus fallback.
- `yarn test` 64/64 (syncpack + oxfmt + typecheck + oxlint + jest), `yarn build`, `yarn docgen` (no diff — props are unchanged), `yarn docs:build`.
- Rendered pixels checked in Chrome, dark and light: the `[Circular]` marker is legible in both, and the shared `config` object visibly expands in both branches.

## API surface

Additive, which is why this ships as a **minor**:

- `ValueType` gains `'circular'`
- `JsonTreeCssVariables.value` gains `--json-tree-color-circular`

The `{ type, props }` change alters what an existing consumer sees for that data shape — it stops hiding a subtree — so it is called out here deliberately rather than buried.

## Docs

New **Circular References** section with its own demo, a note on `$$typeof` detection under Special Value Types, Keyboard Navigation brought in line with what the code now actually does, plus styles-api and README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Safely displays circular object references as `[Circular]` without infinite expansion.
  - Preserves expansion of shared, non-circular references wherever they appear.
  - Added a circular-reference demonstration with self-references, shared data, expansion controls, and unlimited depth.
  - Improved React element detection so React-like plain objects remain expandable.

- **Bug Fixes**
  - Improved keyboard copy behavior, including form-control focus handling and fallback support.

- **Documentation**
  - Documented circular-reference handling, styling, and keyboard-copy behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->