### PR TITLE
feat: edit primitive values in place

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ It requires **Mantine 9.x** and **React 19**.
 
 [Mantine JsonTree](https://gfazioli.github.io/mantine-json-tree) provides a structured, interactive view of heterogeneous data—strings, numbers, booleans, nulls, objects, arrays, and even functions—organized as a collapsible tree. Developers can control initial expansion, show visual indent guides, and customize expand/collapse controls with arbitrary React nodes (e.g., emojis or styled icons) to match their design system. For function values, the component offers flexible rendering modes: show the function signature as text, hide functions entirely, or inspect them as objects when needed.
 
+Set `editable` and the same tree becomes an editor: click a string or a number to change it in place, click a boolean to toggle it. Updates are immutable and rebuild only the path down to the edited node, so every `Date`, `Map`, `Set`, `RegExp`, `BigInt`, function and React element elsewhere in the tree keeps its identity.
+
 Wrapped with Mantine layout primitives like Paper, Stack, and SimpleGrid, JsonTree integrates cleanly into dashboards, developer tools, and documentation pages where readable, navigable data visualization is essential.
 
 ## Features
@@ -81,6 +83,19 @@ import { JsonTree } from '@gfazioli/mantine-json-tree';
 
 function Demo() {
   return <JsonTree data={{ key: "value" }} />;
+}
+```
+
+To let a reader change values, add `editable` and feed `onChange` back through `data` — `JsonTree` keeps no copy of your data:
+
+```tsx
+import { useState } from 'react';
+import { JsonTree } from '@gfazioli/mantine-json-tree';
+
+function Demo() {
+  const [data, setData] = useState({ key: 'value', count: 1, enabled: false });
+
+  return <JsonTree data={data} editable onChange={setData} />;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Wrapped with Mantine layout primitives like Paper, Stack, and SimpleGrid, JsonTr
 ## Features
 
 - Interactive collapsible tree view for any JSON-serializable data
+- **In-place editing** of strings, numbers and booleans (`editable`, `onChange`) — immutable updates that
+  leave every `Date`, `Map`, `Set`, `RegExp`, `BigInt`, function and React element in the tree untouched
 - **Search** with text highlight, filtered tree view, and auto-expand matching branches
 - **Redesigned toolbar** with key count badge, global copy, search toggle, and modern icons
 - **Paper wrapper** with `withBorder` for bordered container look

--- a/docs/data.ts
+++ b/docs/data.ts
@@ -27,7 +27,7 @@ export interface PackageData {
 export const PACKAGE_DATA: PackageData = {
   packageName: '@gfazioli/mantine-json-tree',
   packageDescription:
-    'A Mantine extension component that renders interactive JSON trees with syntax highlighting, collapsible nodes, copy-to-clipboard, and configurable expansion depth.',
+    'A Mantine extension component that renders interactive JSON trees with syntax highlighting, collapsible nodes, in-place value editing, copy-to-clipboard, and configurable expansion depth.',
   mdxFileUrl: 'https://github.com/gfazioli/mantine-json-tree/blob/master/docs/docs.mdx',
   repositoryUrl: 'https://github.com/gfazioli/mantine-json-tree',
   licenseUrl: 'https://github.com/gfazioli/mantine-json-tree/blob/master/LICENSE',

--- a/docs/demos/JsonTree.demo.editable.tsx
+++ b/docs/demos/JsonTree.demo.editable.tsx
@@ -1,0 +1,107 @@
+import { JsonTree } from '@gfazioli/mantine-json-tree';
+import { Paper, Stack, Text } from '@mantine/core';
+import { MantineDemo } from '@mantinex/demo';
+import { useState } from 'react';
+
+const code = `
+import { useState } from 'react';
+import { JsonTree } from "@gfazioli/mantine-json-tree";
+import { Paper, Stack, Text } from '@mantine/core';
+
+function Demo() {
+  const [data, setData] = useState({
+    name: 'Jamie Chen',
+    age: 34,
+    isAdmin: false,
+    createdAt: new Date('2024-01-15T10:30:00Z'),
+    address: {
+      city: 'Anytown',
+      zip: '12345',
+    },
+    tags: ['react', 'mantine'],
+  });
+
+  const [lastChange, setLastChange] = useState(null);
+
+  return (
+    <Stack>
+      <Paper withBorder>
+        <JsonTree
+          data={data}
+          title="profile.json"
+          defaultExpanded
+          maxDepth={-1}
+          editable
+          onChange={(next, change) => {
+            setData(next);
+            setLastChange(change);
+          }}
+          // zip stays read-only even though its type is editable
+          isEditable={({ key }) => key !== 'zip'}
+          validate={({ type, value }) =>
+            type === 'string' && String(value).trim() === '' ? 'Cannot be empty' : null
+          }
+        />
+      </Paper>
+
+      <Text size="sm" c="dimmed">
+        {lastChange
+          ? \`\${lastChange.path}: \${JSON.stringify(lastChange.previousValue)} → \${JSON.stringify(lastChange.value)}\`
+          : 'Click a value to edit it. Enter commits, Escape cancels.'}
+      </Text>
+    </Stack>
+  );
+}
+`;
+
+function Demo() {
+  const [data, setData] = useState<any>({
+    name: 'Jamie Chen',
+    age: 34,
+    isAdmin: false,
+    createdAt: new Date('2024-01-15T10:30:00Z'),
+    address: {
+      city: 'Anytown',
+      zip: '12345',
+    },
+    tags: ['react', 'mantine'],
+  });
+
+  const [lastChange, setLastChange] = useState<any>(null);
+
+  return (
+    <Stack>
+      <Paper withBorder>
+        <JsonTree
+          data={data}
+          title="profile.json"
+          defaultExpanded
+          maxDepth={-1}
+          editable
+          onChange={(next, change) => {
+            setData(next);
+            setLastChange(change);
+          }}
+          // zip stays read-only even though its type is editable
+          isEditable={({ key }) => key !== 'zip'}
+          validate={({ type, value }) =>
+            type === 'string' && String(value).trim() === '' ? 'Cannot be empty' : null
+          }
+        />
+      </Paper>
+
+      <Text size="sm" c="dimmed">
+        {lastChange
+          ? `${lastChange.path}: ${JSON.stringify(lastChange.previousValue)} → ${JSON.stringify(lastChange.value)}`
+          : 'Click a value to edit it. Enter commits, Escape cancels.'}
+      </Text>
+    </Stack>
+  );
+}
+
+export const editable: MantineDemo = {
+  type: 'code',
+  component: Demo,
+  code,
+  defaultExpanded: false,
+};

--- a/docs/demos/JsonTree.demo.editable.tsx
+++ b/docs/demos/JsonTree.demo.editable.tsx
@@ -1,15 +1,33 @@
-import { JsonTree } from '@gfazioli/mantine-json-tree';
+import { JsonTree, JsonTreeChange } from '@gfazioli/mantine-json-tree';
 import { Paper, Stack, Text } from '@mantine/core';
 import { MantineDemo } from '@mantinex/demo';
+
+interface Profile {
+  name: string;
+  age: number;
+  isAdmin: boolean;
+  createdAt: Date;
+  address: { city: string; zip: string };
+  tags: string[];
+}
 import { useState } from 'react';
 
 const code = `
 import { useState } from 'react';
-import { JsonTree } from "@gfazioli/mantine-json-tree";
+import { JsonTree, JsonTreeChange } from "@gfazioli/mantine-json-tree";
 import { Paper, Stack, Text } from '@mantine/core';
 
+interface Profile {
+  name: string;
+  age: number;
+  isAdmin: boolean;
+  createdAt: Date;
+  address: { city: string; zip: string };
+  tags: string[];
+}
+
 function Demo() {
-  const [data, setData] = useState({
+  const [data, setData] = useState<Profile>({
     name: 'Jamie Chen',
     age: 34,
     isAdmin: false,
@@ -21,7 +39,7 @@ function Demo() {
     tags: ['react', 'mantine'],
   });
 
-  const [lastChange, setLastChange] = useState(null);
+  const [lastChange, setLastChange] = useState<JsonTreeChange | null>(null);
 
   return (
     <Stack>
@@ -33,7 +51,8 @@ function Demo() {
           maxDepth={-1}
           editable
           onChange={(next, change) => {
-            setData(next);
+            // editing a value never changes the shape, so the cast is safe
+            setData(next as Profile);
             setLastChange(change);
           }}
           // zip stays read-only even though its type is editable
@@ -55,7 +74,7 @@ function Demo() {
 `;
 
 function Demo() {
-  const [data, setData] = useState<any>({
+  const [data, setData] = useState<Profile>({
     name: 'Jamie Chen',
     age: 34,
     isAdmin: false,
@@ -67,7 +86,7 @@ function Demo() {
     tags: ['react', 'mantine'],
   });
 
-  const [lastChange, setLastChange] = useState<any>(null);
+  const [lastChange, setLastChange] = useState<JsonTreeChange | null>(null);
 
   return (
     <Stack>
@@ -79,7 +98,8 @@ function Demo() {
           maxDepth={-1}
           editable
           onChange={(next, change) => {
-            setData(next);
+            // editing a value never changes the shape, so the cast is safe
+            setData(next as Profile);
             setLastChange(change);
           }}
           // zip stays read-only even though its type is editable

--- a/docs/demos/JsonTree.demo.rootName.tsx
+++ b/docs/demos/JsonTree.demo.rootName.tsx
@@ -4,17 +4,28 @@ import { MantineDemo } from '@mantinex/demo';
 
 const code = `
 import { JsonTree } from '@gfazioli/mantine-json-tree';
+import { Stack } from '@mantine/core';
 
 function Demo() {
   return (
-    <JsonTree
-      data={{ id: 1, name: 'Alice', role: 'admin' }}
-      rootName="response"
-      title="Custom Root Name"
-      withBorder
-      withKeyCountBadge
-      defaultExpanded
-    />
+    <Stack>
+      <JsonTree
+        data={{ id: 1, name: 'Alice', role: 'admin' }}
+        rootName="response"
+        title="Custom Root Name"
+        withBorder
+        withKeyCountBadge
+        defaultExpanded
+      />
+      <JsonTree
+        data={[1, 2, 3]}
+        rootName="items"
+        title="Array Root Name"
+        withBorder
+        withKeyCountBadge
+        defaultExpanded
+      />
+    </Stack>
   );
 }
 `;

--- a/docs/demos/JsonTree.demo.values.tsx
+++ b/docs/demos/JsonTree.demo.values.tsx
@@ -1,12 +1,10 @@
 import { JsonTree } from '@gfazioli/mantine-json-tree';
 import { Paper, Stack } from '@mantine/core';
 import { MantineDemo } from '@mantinex/demo';
-import { dataCode } from './data';
 
 const code = `
 import { JsonTree } from "@gfazioli/mantine-json-tree";
 import { Paper, Stack } from '@mantine/core';
-import { data } from './data';
 
 function Demo() {
   return (
@@ -47,7 +45,9 @@ function Demo() {
         <JsonTree data={42} defaultExpanded title="Number value" />
       </Paper>
       <Paper withBorder>
-        <JsonTree data defaultExpanded title="Boolean value (true)" />
+        {/* eslint-disable-next-line react/jsx-boolean-value -- the shorthand `data` reads as
+            a forgotten prop in a docs snippet, and the explicit value is this row's point */}
+        <JsonTree data={true} defaultExpanded title="Boolean value (true)" />
       </Paper>
       <Paper withBorder>
         <JsonTree data={false} defaultExpanded title="Boolean value (false)" />
@@ -76,9 +76,6 @@ function Demo() {
 export const values: MantineDemo = {
   type: 'code',
   component: Demo,
-  code: [
-    { fileName: 'Demo.tsx', code, language: 'tsx' },
-    { fileName: 'data.ts', code: dataCode, language: 'tsx' },
-  ],
+  code,
   defaultExpanded: false,
 };

--- a/docs/demos/index.ts
+++ b/docs/demos/index.ts
@@ -1,5 +1,6 @@
 export { callbacks } from './JsonTree.demo.callbacks';
 export { circular } from './JsonTree.demo.circular';
+export { editable } from './JsonTree.demo.editable';
 export { configurator } from './JsonTree.demo.configurator';
 export { customIcons } from './JsonTree.demo.customIcons';
 export { functions } from './JsonTree.demo.functions';

--- a/docs/docs.mdx
+++ b/docs/docs.mdx
@@ -3,6 +3,8 @@ import * as demos from './demos';
 
 ## What's new
 
+- **Editable values** — click a string, number or boolean to edit it in place (`editable`, `onChange`)
+- **Circular references** are detected and marked instead of crashing the component
 - **Search** with text highlight, auto-expand, and filtered tree view (`withSearch`)
 - **Redesigned toolbar** with key count badge, global copy, search toggle, and modern icons
 - **Paper wrapper** with `withBorder` for bordered container look
@@ -16,8 +18,6 @@ import * as demos from './demos';
 - Controlled expand/collapse state (`expanded`, `onExpandedChange`)
 - `onExpand` and `onCollapse` callbacks for individual node toggling
 - Keyboard copy: `Ctrl+C` / `Cmd+C` copies the focused node when `withCopyToClipboard` is enabled
-- **Editable values** — click a string, number or boolean to edit it in place (`editable`, `onChange`)
-- **Circular references** are detected and marked instead of crashing the component
 - Responsive `size` prop via Mantine breakpoint objects (CSS-native, no re-renders)
 
 ## Installation
@@ -42,44 +42,11 @@ The `JsonTree` is interactive JSON tree viewer component built with [Mantine's T
 
 <Demo data={demos.configurator} />
 
-## Search
-
-Enable `withSearch` to add a search toggle in the toolbar.
-When active, the tree filters to show only branches with
-matching keys or values. Direct matches get an amber
-background highlight, and the matching text portion is
-highlighted inline. Parent nodes are preserved for context.
-Clearing the search restores the previous expand state.
-
-<Demo data={demos.search} />
-
-### Customizing the search input
-
-Use `searchInputProps` to forward any prop to the internal
-`TextInput` — `classNames`, `styles`, `vars`, `variant`,
-`radius`, `size`, `leftSection`, and so on. Because Mantine
-applies `styles` inline, this works without specificity hacks
-or `!important`.
-
-<Demo data={demos.searchInputStyling} />
-
-## Copy to Clipboard
-
-Both per-node and global copy buttons provide visual
-feedback — the icon briefly changes to a green
-checkmark after a successful copy.
-
-The **global copy** button (`withCopyAll`) copies the
-raw JSON data without the `rootName` wrapper. The
-`rootName` is a display-only label and is not included
-in the copied output. This makes the copied JSON
-directly usable in code and API tools.
-
 ## Editing Values
 
 Set `editable` to let a reader change a value in place. Click a string or a number to open an
 inline editor — `Enter` commits, `Escape` cancels, moving focus commits — or click a boolean to
-toggle it outright, since it has exactly one other state to move to. With a row focused, `Enter`
+toggle it outright, since it has exactly one other state. With a row focused, `Enter`
 opens its editor too, so the whole flow works from the keyboard without adding a tab stop per value.
 
 `JsonTree` is **controlled** while editing: it never keeps its own copy of your data. `onChange`
@@ -108,7 +75,7 @@ Two kinds of node can never be edited, whatever you put in that list:
   data={data}
   editable
   onChange={setData}
-  isEditable={({ path, type }) => path !== 'root.id'}
+  isEditable={({ path }) => path !== 'root.id'}
   validate={({ value }) => (String(value).trim() === '' ? 'Cannot be empty' : null)}
 />
 ```
@@ -125,6 +92,41 @@ Two kinds of node can never be edited, whatever you put in that list:
   node you clicked.
 
 Use `path` for display and logging; use `pathSegments` whenever you need to act on the node.
+
+## Search
+
+Enable `withSearch` to add a search toggle in the toolbar.
+When active, the tree filters to show only branches with
+matching keys or values. Direct matches get an amber
+background highlight, and the matching text portion is
+highlighted inline. Parent nodes are preserved for context.
+Clearing the search restores the previous expand state.
+
+<Demo data={demos.search} />
+
+### Customizing the search input
+
+Use `searchInputProps` to forward any prop to the internal
+`TextInput` — `classNames`, `styles`, `vars`, `variant`,
+`radius`, `size`, `leftSection`, and so on. Because Mantine
+applies `styles` inline, this works without specificity hacks
+or `!important`.
+
+<Demo data={demos.searchInputStyling} />
+
+## Copy to Clipboard
+
+Both per-node and global copy buttons provide visual feedback — the icon briefly changes to a green
+checkmark after a successful copy.
+
+The **global copy** button (`withCopyAll`) copies the raw JSON data without the `rootName` wrapper.
+The `rootName` is a display-only label and is not included in the copied output. This makes the
+copied JSON directly usable in code and API tools.
+
+What lands on the clipboard is what the tree shows. `JSON.stringify` alone cannot express
+everything the tree renders — it returns `undefined` for functions, symbols and `undefined`, and
+throws on `BigInt` and on any value holding a reference cycle — so those fall back to the rendered
+form rather than copying the literal text `undefined` or silently doing nothing.
 
 ## Root Name
 
@@ -227,6 +229,8 @@ Use the `onNodeClick` callback to handle clicks on any node in the tree, and the
 - **Arrow Right**: Expand a collapsed node or move to first child
 - **Arrow Left**: Collapse an expanded node or move to parent
 - **Space**: Toggle node expansion
+- **Enter**: Open the inline editor for the focused row (when `editable` is enabled). Editable
+  values add no tab stop of their own, so a large tree stays one stop, as Mantine's Tree intends
 - **Ctrl+C / Cmd+C**: Copy the focused node's value to clipboard (when `withCopyToClipboard` is
   enabled). With no node focused it falls back to the root, and it never intercepts the shortcut
   while a form control inside the component — such as the search input — holds focus.

--- a/docs/docs.mdx
+++ b/docs/docs.mdx
@@ -52,6 +52,16 @@ opens its editor too, so the whole flow works from the keyboard without adding a
 `JsonTree` is **controlled** while editing: it never keeps its own copy of your data. `onChange`
 hands you the next value, and it only takes effect once you feed it back through `data`.
 
+`data` is typed `unknown`, so `onChange` hands the next value back as `unknown` too. Editing a
+value never changes the shape of the object — a string stays a string, a number a number — so
+casting it back to your own type is safe:
+
+```tsx
+const [data, setData] = useState<Profile>(initial);
+
+<JsonTree data={data} editable onChange={(next) => setData(next as Profile)} />
+```
+
 The original object is never mutated. Only the spine down to the edited node is rebuilt, so every
 `Date`, `Map`, `Set`, `RegExp`, `BigInt`, function and React element elsewhere in the tree keeps
 its identity — a `structuredClone` or a JSON round-trip would flatten or destroy all of them.

--- a/docs/docs.mdx
+++ b/docs/docs.mdx
@@ -16,6 +16,7 @@ import * as demos from './demos';
 - Controlled expand/collapse state (`expanded`, `onExpandedChange`)
 - `onExpand` and `onCollapse` callbacks for individual node toggling
 - Keyboard copy: `Ctrl+C` / `Cmd+C` copies the focused node when `withCopyToClipboard` is enabled
+- **Editable values** — click a string, number or boolean to edit it in place (`editable`, `onChange`)
 - **Circular references** are detected and marked instead of crashing the component
 - Responsive `size` prop via Mantine breakpoint objects (CSS-native, no re-renders)
 
@@ -73,6 +74,57 @@ raw JSON data without the `rootName` wrapper. The
 `rootName` is a display-only label and is not included
 in the copied output. This makes the copied JSON
 directly usable in code and API tools.
+
+## Editing Values
+
+Set `editable` to let a reader change a value in place. Click a string or a number to open an
+inline editor — `Enter` commits, `Escape` cancels, moving focus commits — or click a boolean to
+toggle it outright, since it has exactly one other state to move to. With a row focused, `Enter`
+opens its editor too, so the whole flow works from the keyboard without adding a tab stop per value.
+
+`JsonTree` is **controlled** while editing: it never keeps its own copy of your data. `onChange`
+hands you the next value, and it only takes effect once you feed it back through `data`.
+
+The original object is never mutated. Only the spine down to the edited node is rebuilt, so every
+`Date`, `Map`, `Set`, `RegExp`, `BigInt`, function and React element elsewhere in the tree keeps
+its identity — a `structuredClone` or a JSON round-trip would flatten or destroy all of them.
+
+<Demo data={demos.editable} />
+
+### What can be edited
+
+`editableTypes` defaults to `['string', 'number', 'boolean']`; anything outside it stays read-only.
+Two kinds of node can never be edited, whatever you put in that list:
+
+- **`Map` and `Set` entries.** They are displayed under a synthetic key — a `Map` key can be any
+  value at all, including an object — so there is no address to write back to.
+- **Function properties expanded with `displayFunctions="as-object"`.** Those properties belong to
+  a synthetic object that does not exist in your data.
+
+`isEditable` gates individual nodes, and `validate` rejects a value by returning a message:
+
+```tsx
+<JsonTree
+  data={data}
+  editable
+  onChange={setData}
+  isEditable={({ path, type }) => path !== 'root.id'}
+  validate={({ value }) => (String(value).trim() === '' ? 'Cannot be empty' : null)}
+/>
+```
+
+### Addressing a node
+
+`onChange` receives a change object carrying both ways of naming the node:
+
+- `path` — the display label, e.g. `root.address.city`. It is **not unique**: `{ 'a.b': 1 }` and
+  `{ a: { b: 1 } }` both produce `root.a.b`, and an array index reads the same as a numeric object
+  key.
+- `pathSegments` — the real address, one step per level, with object keys as strings and array
+  indices as numbers. This is what the write is performed against, so an edit always lands on the
+  node you clicked.
+
+Use `path` for display and logging; use `pathSegments` whenever you need to act on the node.
 
 ## Root Name
 

--- a/docs/styles-api/JsonTree.styles-api.ts
+++ b/docs/styles-api/JsonTree.styles-api.ts
@@ -24,6 +24,7 @@ export const JsonTreeStylesApi: StylesApiData<JsonTreeFactory> = {
     copyButton: 'Copy to clipboard button',
     ellipsis: 'Element that renders ellipsis for collapsed nodes',
     lineNumber: 'Element that renders line numbers',
+    valueEditor: 'Wrapper around the inline editor shown while a value is being edited',
   },
 
   vars: {
@@ -55,6 +56,7 @@ export const JsonTreeStylesApi: StylesApiData<JsonTreeFactory> = {
       '--json-tree-color-map': 'Color for Map collection values',
       '--json-tree-color-set': 'Color for Set collection values',
       '--json-tree-color-circular': 'Color for circular reference markers',
+      '--json-tree-color-editable-outline': 'Outline color shown when hovering an editable value',
     },
     bracket: {
       '--json-tree-color-bracket': 'Color for brackets and punctuation',
@@ -72,6 +74,7 @@ export const JsonTreeStylesApi: StylesApiData<JsonTreeFactory> = {
     ellipsis: {
       '--json-tree-color-ellipsis': 'Color for the ellipsis indicator on collapsed nodes',
     },
+    valueEditor: {},
     lineNumber: {
       '--json-tree-color-line-number': 'Color for line numbers',
     },

--- a/package/package.json
+++ b/package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gfazioli/mantine-json-tree",
   "version": "3.3.0",
-  "description": "A Mantine extension component that renders interactive JSON trees with syntax highlighting, collapsible nodes, copy-to-clipboard, and configurable expansion depth.",
+  "description": "A Mantine extension component that renders interactive JSON trees with syntax highlighting, collapsible nodes, in-place value editing, copy-to-clipboard, and configurable expansion depth.",
   "homepage": "https://gfazioli.github.io/mantine-json-tree/",
   "packageManager": "yarn@4.0.1",
   "license": "MIT",
@@ -10,7 +10,9 @@
     "collapsible-tree",
     "component",
     "developer-tools",
+    "editable",
     "extension",
+    "json-editor",
     "json-tree",
     "json-view",
     "json-viewer",

--- a/package/src/JsonTree.module.css
+++ b/package/src/JsonTree.module.css
@@ -114,6 +114,33 @@
     color: var(--json-tree-color-circular);
     font-style: italic;
   }
+
+  /* Editable values advertise themselves on hover rather than permanently, so a
+     read-heavy tree does not turn into a wall of input boxes. */
+  &[data-editable] {
+    cursor: text;
+    outline: 1px dashed transparent;
+    outline-offset: 1px;
+    transition:
+      outline-color 120ms ease,
+      background-color 120ms ease;
+  }
+
+  &[data-editable]:hover {
+    outline-color: var(--json-tree-color-editable-outline);
+  }
+
+  /* A boolean has exactly one other state, so clicking it toggles rather than
+     opening an editor — the cursor says so. */
+  &[data-editable][data-type='boolean'] {
+    cursor: pointer;
+  }
+}
+
+.valueEditor {
+  display: inline-flex;
+  min-width: 120px;
+  max-width: 320px;
 }
 
 .bracket {

--- a/package/src/JsonTree.module.css
+++ b/package/src/JsonTree.module.css
@@ -130,6 +130,13 @@
     outline-color: var(--json-tree-color-editable-outline);
   }
 
+  /* A keyboard user focuses the row, never the value cell, so :hover alone would
+     leave the Enter-to-edit affordance invisible to them. */
+  :global(li[role='treeitem']:focus) &[data-editable],
+  :global(li[role='treeitem']:focus-visible) &[data-editable] {
+    outline-color: var(--json-tree-color-editable-outline);
+  }
+
   /* A boolean has exactly one other state, so clicking it toggles rather than
      opening an editor — the cursor says so. */
   &[data-editable][data-type='boolean'] {

--- a/package/src/JsonTree.test.tsx
+++ b/package/src/JsonTree.test.tsx
@@ -1084,5 +1084,43 @@ describe('JsonTree', () => {
       await user.keyboard('{Enter}');
       expect(onChange.mock.calls[0][0].name).toBe('a b c');
     });
+    it('runs validate on a boolean toggle too', async () => {
+      // the toggle skips the editor, but it is still a commit — a consumer
+      // `validate` that rejects the new state must be able to stop it
+      const user = userEvent.setup();
+      const validate = jest.fn((_payload: any) => 'not allowed');
+      const { container, onChange } = setup({ editable: true, validate });
+
+      await user.click(cell(container, 'root.isAdmin'));
+
+      expect(validate).toHaveBeenCalledTimes(1);
+      expect(validate.mock.calls[0][0]).toMatchObject({ type: 'boolean', value: true });
+      expect(onChange).not.toHaveBeenCalled();
+      expect(cell(container, 'root.isAdmin').textContent).toBe('false');
+    });
+
+    it('leaves Enter to a focused control inside the row', async () => {
+      // the row can hold its own buttons; taking Enter here would make the
+      // per-node copy button unreachable from the keyboard
+      const user = userEvent.setup();
+      // after setup(): userEvent installs a clipboard stub of its own
+      const writeText = jest.fn().mockResolvedValue(undefined);
+      Object.defineProperty(navigator, 'clipboard', {
+        value: { writeText },
+        configurable: true,
+        writable: true,
+      });
+      const { container } = setup({ editable: true, withCopyToClipboard: true });
+
+      const row = container.querySelector<HTMLElement>(
+        'li[role="treeitem"][data-value="root.name"]'
+      )!;
+      row.querySelector('button')!.focus();
+      await user.keyboard('{Enter}');
+
+      expect(container.querySelector('[class*="valueEditor"]')).toBeNull();
+      await waitFor(() => expect(writeText).toHaveBeenCalled());
+      expect(writeText.mock.calls[0][0]).toBe('"John"');
+    });
   });
 });

--- a/package/src/JsonTree.test.tsx
+++ b/package/src/JsonTree.test.tsx
@@ -4,6 +4,8 @@ import { fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { JsonTree } from './JsonTree';
+import { setValueAtPath } from './lib/path';
+import { convertToTreeData, filterTreeBySearch, searchTree, stringifyValue } from './lib/utils';
 
 describe('JsonTree', () => {
   it('renders without crashing', () => {
@@ -466,8 +468,6 @@ describe('JsonTree', () => {
 
   describe('search utilities', () => {
     it('searchTree finds matches by key name', () => {
-      const { searchTree } = require('./lib/utils');
-      const { convertToTreeData } = require('./lib/utils');
       const treeData = [convertToTreeData({ name: 'Alice', age: 30 }, 'root', 'root', 0)];
       const result = searchTree(treeData, 'name');
       expect(result.directMatches.size).toBeGreaterThan(0);
@@ -475,14 +475,12 @@ describe('JsonTree', () => {
     });
 
     it('searchTree finds matches by value', () => {
-      const { searchTree, convertToTreeData } = require('./lib/utils');
       const treeData = [convertToTreeData({ name: 'Alice', age: 30 }, 'root', 'root', 0)];
       const result = searchTree(treeData, 'Alice');
       expect(result.directMatches.size).toBeGreaterThan(0);
     });
 
     it('searchTree returns empty for empty query', () => {
-      const { searchTree, convertToTreeData } = require('./lib/utils');
       const treeData = [convertToTreeData({ a: 1 }, 'root', 'root', 0)];
       const result = searchTree(treeData, '');
       expect(result.directMatches.size).toBe(0);
@@ -490,7 +488,6 @@ describe('JsonTree', () => {
     });
 
     it('filterTreeBySearch keeps only matching branches', () => {
-      const { filterTreeBySearch, searchTree, convertToTreeData } = require('./lib/utils');
       const data = { a: { b: 'hello' }, c: { d: 'world' } };
       const treeData = [convertToTreeData(data, 'root', 'root', 0)];
       const { matchedPaths } = searchTree(treeData, 'hello');
@@ -505,7 +502,6 @@ describe('JsonTree', () => {
     });
 
     it('searchTree is case insensitive', () => {
-      const { searchTree, convertToTreeData } = require('./lib/utils');
       const treeData = [convertToTreeData({ Name: 'ALICE' }, 'root', 'root', 0)];
       const result = searchTree(treeData, 'alice');
       expect(result.directMatches.size).toBeGreaterThan(0);
@@ -636,8 +632,6 @@ describe('JsonTree', () => {
     });
   });
   describe('clipboard serialization', () => {
-    const { stringifyValue } = require('./lib/utils');
-
     it('keeps JSON-representable values exactly as JSON.stringify would', () => {
       expect(stringifyValue({ a: 1 })).toBe(JSON.stringify({ a: 1 }, null, 2));
       expect(stringifyValue([1, 'two'])).toBe(JSON.stringify([1, 'two'], null, 2));
@@ -712,9 +706,6 @@ describe('JsonTree', () => {
     });
   });
   describe('addressable paths', () => {
-    const { convertToTreeData } = require('./lib/utils');
-    const { setValueAtPath } = require('./lib/path');
-
     const findByPath = (node: any, path: string): any => {
       if (node.nodeData?.path === path) {
         return node;
@@ -736,13 +727,13 @@ describe('JsonTree', () => {
     it('addresses object keys and array indices, indices as numbers', () => {
       const tree = convertToTreeData({ address: { city: 'X' }, courses: ['a'] }, 'root', 'root');
 
-      expect(tree.nodeData.pathSegments).toEqual([]);
-      expect(findByPath(tree, 'root.address.city').nodeData.pathSegments).toEqual([
+      expect(tree.nodeData?.pathSegments).toEqual([]);
+      expect(findByPath(tree, 'root.address.city').nodeData?.pathSegments).toEqual([
         'address',
         'city',
       ]);
       // a numeric segment marks an array index, a string marks an object key
-      expect(findByPath(tree, 'root.courses.0').nodeData.pathSegments).toEqual(['courses', 0]);
+      expect(findByPath(tree, 'root.courses.0').nodeData?.pathSegments).toEqual(['courses', 0]);
     });
 
     it('separates a dotted key from a nested object that share a path string', () => {
@@ -766,7 +757,7 @@ describe('JsonTree', () => {
 
       // a Map key can be any value, a Set has no keys: neither can be written back
       expect(unaddressable.length).toBe(2);
-      expect(findByPath(tree, 'root.m').nodeData.pathSegments).toEqual(['m']);
+      expect(findByPath(tree, 'root.m').nodeData?.pathSegments).toEqual(['m']);
     });
 
     it('leaves function properties unaddressable when expanded as an object', () => {
@@ -776,7 +767,7 @@ describe('JsonTree', () => {
 
       const meta = collect(tree).find((n: any) => n.nodeData?.key === 'meta');
       // the properties belong to a synthetic object that is not in the data
-      expect(meta.nodeData.pathSegments).toBeUndefined();
+      expect(meta.nodeData?.pathSegments).toBeUndefined();
     });
 
     it('round-trips: a node address written back lands on that node', () => {
@@ -1019,6 +1010,79 @@ describe('JsonTree', () => {
       expect(html).not.toContain('editable-outline');
       expect(html).not.toContain('data-editable');
       expect(html).not.toContain('data-edit-key');
+    });
+    it('rejects an empty numeric field instead of committing zero', async () => {
+      // NumberInput reports an empty field as '', and Number('') is 0 — committing
+      // that writes a zero the user never typed while trying to clear the field
+      const user = userEvent.setup();
+      const { container, onChange } = setup({ editable: true });
+
+      await user.click(cell(container, 'root.age'));
+      await user.clear(input(container));
+      await user.keyboard('{Enter}');
+
+      expect(onChange).not.toHaveBeenCalled();
+      expect(container.textContent).toContain('Required');
+      expect(container.querySelector('input')).not.toBeNull();
+    });
+
+    it('never offers to edit a property of a class instance', () => {
+      // it renders as an object, but setValueAtPath refuses a non-plain prototype:
+      // offering the edit would throw at commit time
+      class Profile {
+        constructor(public city = 'Anytown') {}
+      }
+      const { container } = setup(
+        { editable: true },
+        { profile: new Profile(), plain: { city: 'X' } }
+      );
+
+      expect(cell(container, 'root.profile.city').getAttribute('data-editable')).toBeNull();
+      // a plain object next to it must stay editable — no over-correction
+      expect(cell(container, 'root.plain.city').getAttribute('data-editable')).toBe('true');
+    });
+
+    it('returns focus to the row when an edit is committed', async () => {
+      const user = userEvent.setup();
+      const { container } = setup({ editable: true });
+
+      await user.click(cell(container, 'root.name'));
+      await user.keyboard('{Enter}');
+
+      // the editor unmounts with the input inside it; without this the keyboard
+      // user lands on <body> and arrow navigation stops working
+      expect(document.activeElement?.getAttribute('data-value')).toBe('root.name');
+    });
+
+    it('returns focus to the row when an edit is cancelled', async () => {
+      const user = userEvent.setup();
+      const { container } = setup({ editable: true });
+
+      await user.click(cell(container, 'root.name'));
+      await user.keyboard('{Escape}');
+
+      expect(document.activeElement?.getAttribute('data-value')).toBe('root.name');
+    });
+    it('keeps the Tree guard when editorProps carries its own handlers', async () => {
+      // spread last, a consumer onKeyDown replaced the guard and Mantine's Tree
+      // reclaimed Space and the arrow keys — the field stopped accepting spaces
+      const user = userEvent.setup();
+      const consumerKeyDown = jest.fn();
+      const { container, onChange } = setup({
+        editable: true,
+        editorProps: { onKeyDown: consumerKeyDown },
+      });
+
+      await user.click(cell(container, 'root.name'));
+      await user.clear(input(container));
+      await user.type(input(container), 'a b c');
+
+      expect(input(container).value).toBe('a b c');
+      // the consumer's handler still runs — it is composed, not discarded
+      expect(consumerKeyDown).toHaveBeenCalled();
+
+      await user.keyboard('{Enter}');
+      expect(onChange.mock.calls[0][0].name).toBe('a b c');
     });
   });
 });

--- a/package/src/JsonTree.test.tsx
+++ b/package/src/JsonTree.test.tsx
@@ -3,11 +3,41 @@ import { Loader } from '@mantine/core';
 import { fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-import { JsonTree } from './JsonTree';
+import { JsonTree, type JsonTreeNodePayload } from './JsonTree';
 import { setValueAtPath } from './lib/path';
 import { convertToTreeData, filterTreeBySearch, searchTree, stringifyValue } from './lib/utils';
 
+/** Set by any test that stubs the clipboard; run in a global afterEach. */
+let restoreClipboardAfter: (() => void) | null = null;
+
+/**
+ * Replace navigator.clipboard for one test and hand back a restore function.
+ * Overwriting it without restoring leaks the spy into later tests.
+ */
+function stubClipboard() {
+  const original = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
+  const writeText = jest.fn().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText },
+    configurable: true,
+    writable: true,
+  });
+  const restore = () => {
+    if (original) {
+      Object.defineProperty(navigator, 'clipboard', original);
+    } else {
+      delete (navigator as { clipboard?: unknown }).clipboard;
+    }
+  };
+  return { writeText, restore };
+}
+
 describe('JsonTree', () => {
+  afterEach(() => {
+    restoreClipboardAfter?.();
+    restoreClipboardAfter = null;
+  });
+
   it('renders without crashing', () => {
     const { container } = render(<JsonTree data={[]} />);
     expect(container).toBeTruthy();
@@ -509,12 +539,8 @@ describe('JsonTree', () => {
   });
   describe('keyboard copy targeting', () => {
     const mockClipboard = () => {
-      const writeText = jest.fn().mockResolvedValue(undefined);
-      Object.defineProperty(navigator, 'clipboard', {
-        value: { writeText },
-        configurable: true,
-        writable: true,
-      });
+      const { writeText, restore } = stubClipboard();
+      restoreClipboardAfter = restore;
       return writeText;
     };
 
@@ -684,12 +710,8 @@ describe('JsonTree', () => {
     });
 
     it('copies a node holding a cycle instead of doing nothing', async () => {
-      const writeText = jest.fn().mockResolvedValue(undefined);
-      Object.defineProperty(navigator, 'clipboard', {
-        value: { writeText },
-        configurable: true,
-        writable: true,
-      });
+      const { writeText, restore } = stubClipboard();
+      restoreClipboardAfter = restore;
 
       const data: any = { id: 'root' };
       data.self = data;
@@ -1088,7 +1110,7 @@ describe('JsonTree', () => {
       // the toggle skips the editor, but it is still a commit — a consumer
       // `validate` that rejects the new state must be able to stop it
       const user = userEvent.setup();
-      const validate = jest.fn((_payload: any) => 'not allowed');
+      const validate = jest.fn((_payload: JsonTreeNodePayload) => 'not allowed');
       const { container, onChange } = setup({ editable: true, validate });
 
       await user.click(cell(container, 'root.isAdmin'));
@@ -1104,12 +1126,8 @@ describe('JsonTree', () => {
       // per-node copy button unreachable from the keyboard
       const user = userEvent.setup();
       // after setup(): userEvent installs a clipboard stub of its own
-      const writeText = jest.fn().mockResolvedValue(undefined);
-      Object.defineProperty(navigator, 'clipboard', {
-        value: { writeText },
-        configurable: true,
-        writable: true,
-      });
+      const { writeText, restore } = stubClipboard();
+      restoreClipboardAfter = restore;
       const { container } = setup({ editable: true, withCopyToClipboard: true });
 
       const row = container.querySelector<HTMLElement>(
@@ -1121,6 +1139,30 @@ describe('JsonTree', () => {
       expect(container.querySelector('[class*="valueEditor"]')).toBeNull();
       await waitFor(() => expect(writeText).toHaveBeenCalled());
       expect(writeText.mock.calls[0][0]).toBe('"John"');
+    });
+    it('names the editor field for assistive technology', async () => {
+      // an axe run on the open editor reported `label` and `label-title-only`:
+      // the field was announced blank, with no clue which key it belonged to
+      const user = userEvent.setup();
+      const { container } = setup({ editable: true });
+
+      await user.click(cell(container, 'root.name'));
+
+      expect(input(container).getAttribute('aria-label')).toBe('Edit name');
+      // and it stays overridable
+      expect(input(container).getAttribute('aria-invalid')).toBeNull();
+    });
+
+    it('lets a consumer override the editor field name', async () => {
+      const user = userEvent.setup();
+      const { container } = setup({
+        editable: true,
+        editorProps: { 'aria-label': 'Full name' },
+      });
+
+      await user.click(cell(container, 'root.name'));
+
+      expect(input(container).getAttribute('aria-label')).toBe('Full name');
     });
   });
 });

--- a/package/src/JsonTree.test.tsx
+++ b/package/src/JsonTree.test.tsx
@@ -1,6 +1,7 @@
 import { render } from '@mantine-tests/core';
 import { Loader } from '@mantine/core';
 import { fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { JsonTree } from './JsonTree';
 
@@ -708,6 +709,306 @@ describe('JsonTree', () => {
 
       await waitFor(() => expect(writeText).toHaveBeenCalled());
       expect(writeText.mock.calls[0][0]).toContain('"self": "[Circular]"');
+    });
+  });
+  describe('addressable paths', () => {
+    const { convertToTreeData } = require('./lib/utils');
+    const { setValueAtPath } = require('./lib/path');
+
+    const findByPath = (node: any, path: string): any => {
+      if (node.nodeData?.path === path) {
+        return node;
+      }
+      for (const child of node.children ?? []) {
+        const hit = findByPath(child, path);
+        if (hit) {
+          return hit;
+        }
+      }
+      return null;
+    };
+    const collect = (node: any, out: any[] = []): any[] => {
+      out.push(node);
+      (node.children ?? []).forEach((c: any) => collect(c, out));
+      return out;
+    };
+
+    it('addresses object keys and array indices, indices as numbers', () => {
+      const tree = convertToTreeData({ address: { city: 'X' }, courses: ['a'] }, 'root', 'root');
+
+      expect(tree.nodeData.pathSegments).toEqual([]);
+      expect(findByPath(tree, 'root.address.city').nodeData.pathSegments).toEqual([
+        'address',
+        'city',
+      ]);
+      // a numeric segment marks an array index, a string marks an object key
+      expect(findByPath(tree, 'root.courses.0').nodeData.pathSegments).toEqual(['courses', 0]);
+    });
+
+    it('separates a dotted key from a nested object that share a path string', () => {
+      const tree = convertToTreeData({ 'a.b': 1, a: { b: 2 } }, 'root', 'root');
+      const colliding = collect(tree).filter((n: any) => n.nodeData?.path === 'root.a.b');
+
+      // the display path cannot tell them apart — that is the whole point
+      expect(colliding).toHaveLength(2);
+      expect(colliding.map((n: any) => n.nodeData.pathSegments)).toEqual([['a.b'], ['a', 'b']]);
+    });
+
+    it('leaves Map and Set entries unaddressable', () => {
+      const tree = convertToTreeData(
+        { m: new Map<any, any>([[{ id: 1 }, 'v']]), s: new Set(['v']) },
+        'root',
+        'root'
+      );
+      const unaddressable = collect(tree).filter(
+        (n: any) => n.nodeData?.pathSegments === undefined
+      );
+
+      // a Map key can be any value, a Set has no keys: neither can be written back
+      expect(unaddressable.length).toBe(2);
+      expect(findByPath(tree, 'root.m').nodeData.pathSegments).toEqual(['m']);
+    });
+
+    it('leaves function properties unaddressable when expanded as an object', () => {
+      const fn = function handleClick() {};
+      (fn as any).meta = 'x';
+      const tree = convertToTreeData({ fn }, 'root', 'root', 0, 'as-object');
+
+      const meta = collect(tree).find((n: any) => n.nodeData?.key === 'meta');
+      // the properties belong to a synthetic object that is not in the data
+      expect(meta.nodeData.pathSegments).toBeUndefined();
+    });
+
+    it('round-trips: a node address written back lands on that node', () => {
+      const data = { 'a.b': 'dotted', a: { b: 'nested' }, list: ['x', 'y'] };
+      const tree = convertToTreeData(data, 'root', 'root');
+      const colliding = collect(tree).filter((n: any) => n.nodeData?.path === 'root.a.b');
+
+      const afterDotted = setValueAtPath(data, colliding[0].nodeData.pathSegments, 'EDITED');
+      expect(afterDotted).toEqual({ 'a.b': 'EDITED', a: { b: 'nested' }, list: ['x', 'y'] });
+
+      const afterNested = setValueAtPath(data, colliding[1].nodeData.pathSegments, 'EDITED');
+      expect(afterNested).toEqual({ 'a.b': 'dotted', a: { b: 'EDITED' }, list: ['x', 'y'] });
+
+      const item = findByPath(tree, 'root.list.1');
+      const afterItem: any = setValueAtPath(data, item.nodeData.pathSegments, 'EDITED');
+      expect(afterItem.list).toEqual(['x', 'EDITED']);
+      expect(Array.isArray(afterItem.list)).toBe(true);
+    });
+  });
+  describe('editable values', () => {
+    const cell = (container: HTMLElement, path: string) =>
+      container.querySelector<HTMLElement>(
+        `li[role="treeitem"][data-value="${path}"] [data-type]`
+      )!;
+    const input = (container: HTMLElement) => container.querySelector<HTMLInputElement>('input')!;
+
+    const setup = (props: any = {}, data: any = { name: 'John', age: 30, isAdmin: false }) => {
+      const onChange = jest.fn();
+      const utils = render(
+        <JsonTree data={data} defaultExpanded maxDepth={-1} onChange={onChange} {...props} />
+      );
+      return { ...utils, onChange };
+    };
+
+    it('is read-only until editable is set', () => {
+      const { container, onChange } = setup();
+      fireEvent.click(cell(container, 'root.name'));
+      expect(container.querySelector('input')).toBeNull();
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('opens an editor when an editable value is clicked', () => {
+      const { container } = setup({ editable: true });
+      expect(cell(container, 'root.name').getAttribute('data-editable')).toBe('true');
+      fireEvent.click(cell(container, 'root.name'));
+      expect(input(container).value).toBe('John');
+    });
+
+    it('commits on Enter with the next data and a change payload', async () => {
+      const user = userEvent.setup();
+      const { container, onChange } = setup({ editable: true });
+
+      await user.click(cell(container, 'root.name'));
+      await user.clear(input(container));
+      await user.type(input(container), 'Jane{Enter}');
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      const [nextData, change] = onChange.mock.calls[0];
+      expect(nextData).toEqual({ name: 'Jane', age: 30, isAdmin: false });
+      expect(change).toMatchObject({
+        path: 'root.name',
+        pathSegments: ['name'],
+        key: 'name',
+        type: 'string',
+        previousValue: 'John',
+        value: 'Jane',
+      });
+    });
+
+    it('types spaces and moves the caret with arrows inside the editor', async () => {
+      // Mantine's Tree preventDefaults Space and the arrow keys on the row above;
+      // without the editor stopping propagation the field stays empty
+      const user = userEvent.setup();
+      const { container, onChange } = setup({ editable: true });
+
+      await user.click(cell(container, 'root.name'));
+      await user.clear(input(container));
+      await user.type(input(container), 'a b c');
+      expect(input(container).value).toBe('a b c');
+
+      await user.keyboard('{ArrowLeft}{ArrowLeft}X');
+      expect(input(container).value).toBe('a bX c');
+      expect(document.activeElement).toBe(input(container));
+
+      await user.keyboard('{Enter}');
+      expect(onChange.mock.calls[0][0]).toEqual({ name: 'a bX c', age: 30, isAdmin: false });
+    });
+
+    it('cancels on Escape without reporting a change', async () => {
+      const user = userEvent.setup();
+      const { container, onChange } = setup({ editable: true });
+
+      await user.click(cell(container, 'root.name'));
+      await user.clear(input(container));
+      await user.type(input(container), 'Jane{Escape}');
+
+      expect(onChange).not.toHaveBeenCalled();
+      expect(container.querySelector('input')).toBeNull();
+    });
+
+    it('commits on blur', async () => {
+      const user = userEvent.setup();
+      const { container, onChange } = setup({ editable: true });
+
+      await user.click(cell(container, 'root.name'));
+      await user.clear(input(container));
+      await user.type(input(container), 'Jane');
+      fireEvent.blur(input(container));
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange.mock.calls[0][0]).toEqual({ name: 'Jane', age: 30, isAdmin: false });
+    });
+
+    it('edits a number as a number, not a string', async () => {
+      const user = userEvent.setup();
+      const { container, onChange } = setup({ editable: true });
+
+      await user.click(cell(container, 'root.age'));
+      await user.clear(input(container));
+      await user.type(input(container), '31{Enter}');
+
+      expect(onChange.mock.calls[0][0].age).toBe(31);
+    });
+
+    it('toggles a boolean on click without opening an editor', () => {
+      const { container, onChange } = setup({ editable: true });
+
+      fireEvent.click(cell(container, 'root.isAdmin'));
+
+      expect(container.querySelector('input')).toBeNull();
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange.mock.calls[0][0].isAdmin).toBe(true);
+    });
+
+    it('honours editableTypes', () => {
+      const { container } = setup({ editable: true, editableTypes: ['string'] });
+      expect(cell(container, 'root.name').getAttribute('data-editable')).toBe('true');
+      expect(cell(container, 'root.age').getAttribute('data-editable')).toBeNull();
+    });
+
+    it('honours the isEditable gate', () => {
+      const { container } = setup({
+        editable: true,
+        isEditable: ({ path }: any) => path !== 'root.name',
+      });
+      expect(cell(container, 'root.name').getAttribute('data-editable')).toBeNull();
+      expect(cell(container, 'root.age').getAttribute('data-editable')).toBe('true');
+    });
+
+    it('rejects a value that fails validation', async () => {
+      const user = userEvent.setup();
+      const { container, onChange } = setup({
+        editable: true,
+        validate: ({ value }: any) => (String(value).length === 0 ? 'Required' : null),
+      });
+
+      await user.click(cell(container, 'root.name'));
+      await user.clear(input(container));
+      await user.type(input(container), '{Enter}');
+
+      expect(onChange).not.toHaveBeenCalled();
+      expect(container.textContent).toContain('Required');
+      expect(container.querySelector('input')).not.toBeNull();
+    });
+
+    it('never offers to edit a Map or Set entry', () => {
+      const { container } = setup(
+        { editable: true },
+        { m: new Map([['k', 'v']]), s: new Set(['v']), plain: 'yes' }
+      );
+      // their keys are synthetic, so there is no address to write back to
+      const editable = container.querySelectorAll('[data-editable]');
+      expect(editable).toHaveLength(1);
+      expect(editable[0].getAttribute('data-value')).toBe('"yes"');
+    });
+
+    it('writes to the right node when two nodes share a display path', async () => {
+      const user = userEvent.setup();
+      const { container, onChange } = setup(
+        { editable: true },
+        { 'a.b': 'dotted', a: { b: 'nested' } }
+      );
+
+      // both rows render at data-value="root.a.b"
+      const rows = container.querySelectorAll('li[role="treeitem"][data-value="root.a.b"]');
+      expect(rows).toHaveLength(2);
+
+      const nestedCell = rows[1].querySelector<HTMLElement>('[data-editable]')!;
+      await user.click(nestedCell);
+      await user.clear(input(container));
+      await user.type(input(container), 'EDITED{Enter}');
+
+      expect(onChange.mock.calls[0][0]).toEqual({ 'a.b': 'dotted', a: { b: 'EDITED' } });
+      expect(onChange.mock.calls[0][1].pathSegments).toEqual(['a', 'b']);
+    });
+
+    it('keeps non-JSON values elsewhere in the tree intact', async () => {
+      const user = userEvent.setup();
+      const date = new Date('2024-01-15T10:30:00Z');
+      const map = new Map([['k', 'v']]);
+      const { container, onChange } = setup({ editable: true }, { label: 'old', date, map });
+
+      await user.click(cell(container, 'root.label'));
+      await user.clear(input(container));
+      await user.type(input(container), 'new{Enter}');
+
+      const next = onChange.mock.calls[0][0];
+      // identity, not equality — a clone or JSON round-trip would destroy these
+      expect(next.date).toBe(date);
+      expect(next.map).toBe(map);
+    });
+
+    it('opens the editor with Enter on the focused row', async () => {
+      const user = userEvent.setup();
+      const { container } = setup({ editable: true });
+
+      const row = container.querySelector<HTMLElement>(
+        'li[role="treeitem"][data-value="root.name"]'
+      )!;
+      row.focus();
+      await user.keyboard('{Enter}');
+
+      expect(input(container).value).toBe('John');
+    });
+
+    it('adds no tab stop for editable values', () => {
+      // one tab stop for the whole tree, as Mantine intends — a stop per value
+      // would make a large tree impossible to tab past
+      const { container } = setup({ editable: true });
+      const cells = container.querySelectorAll('[data-editable]');
+      expect(cells.length).toBeGreaterThan(0);
+      cells.forEach((c) => expect(c.getAttribute('tabindex')).toBeNull());
     });
   });
 });

--- a/package/src/JsonTree.test.tsx
+++ b/package/src/JsonTree.test.tsx
@@ -1010,5 +1010,15 @@ describe('JsonTree', () => {
       expect(cells.length).toBeGreaterThan(0);
       cells.forEach((c) => expect(c.getAttribute('tabindex')).toBeNull());
     });
+    it('adds nothing to the markup when editing is off', () => {
+      // the read-only render path must stay exactly what it was before `editable`
+      // existed, down to the inline custom properties
+      const { container } = render(<JsonTree data={{ a: 1 }} defaultExpanded maxDepth={-1} />);
+      const html = container.innerHTML;
+
+      expect(html).not.toContain('editable-outline');
+      expect(html).not.toContain('data-editable');
+      expect(html).not.toContain('data-edit-key');
+    });
   });
 });

--- a/package/src/JsonTree.tsx
+++ b/package/src/JsonTree.tsx
@@ -376,6 +376,14 @@ export const defaultProps: Partial<JsonTreeProps> = {
   editableTypes: ['string', 'number', 'boolean'],
 };
 
+/** Elements that own the Enter key themselves — activating them must win over editing. */
+const KEYBOARD_ACTIVATED_SELECTOR =
+  'button, a[href], input, textarea, select, [contenteditable]:not([contenteditable="false"])';
+
+/** Form controls whose own copy shortcut must not be hijacked. */
+const FORM_CONTROL_SELECTOR =
+  'input, textarea, select, [contenteditable]:not([contenteditable="false"])';
+
 interface RenderNodeContext {
   getStyles: ReturnType<typeof useStyles<JsonTreeFactory>>;
   copyToClipboardIcon: React.ReactNode;
@@ -648,8 +656,14 @@ function renderJSONNode(
                       event.stopPropagation();
                       if (type === 'boolean') {
                         // a boolean has exactly one other state, so there is
-                        // nothing to type: toggle it and skip the editor
-                        ctx.onCommitEdit?.(jsonNode, !value);
+                        // nothing to type: toggle it and skip the editor. It is
+                        // still a commit, so `validate` gets its say — refusing
+                        // the toggle is the feedback, since there is no field to
+                        // hang a message on.
+                        const next = !value;
+                        if ((ctx.validateNode?.(jsonNode, next) ?? null) === null) {
+                          ctx.onCommitEdit?.(jsonNode, next);
+                        }
                         return;
                       }
                       ctx.onStartEdit?.(
@@ -1080,6 +1094,13 @@ export const JsonTree = factory<JsonTreeFactory>((_props) => {
       // keeps one code path for mouse and keyboard — and, more importantly,
       // avoids giving every value its own tab stop just to be reachable.
       if (editable && e.key === 'Enter' && !e.metaKey && !e.ctrlKey && !e.altKey) {
+        // A row can hold its own controls — the per-node copy button, a link in a
+        // custom title. Enter belongs to whichever one has focus; taking it here
+        // would leave that control unreachable from the keyboard, which is the
+        // exact failure this shortcut exists to avoid elsewhere.
+        if ((e.target as HTMLElement | null)?.closest?.(KEYBOARD_ACTIVATED_SELECTOR)) {
+          return;
+        }
         const row = (document.activeElement as HTMLElement | null)?.closest?.('[role="treeitem"]');
         if (row && (e.currentTarget as HTMLElement).contains(row)) {
           const cell = Array.from(row.querySelectorAll<HTMLElement>('[data-edit-key]')).find(
@@ -1101,11 +1122,7 @@ export const JsonTree = factory<JsonTreeFactory>((_props) => {
       // Never hijack the native copy of a selection made inside a form control
       // rendered within the tree (the search input, a custom `title`, …).
       const target = e.target as HTMLElement | null;
-      if (
-        target?.closest?.(
-          'input, textarea, select, [contenteditable]:not([contenteditable="false"])'
-        )
-      ) {
+      if (target?.closest?.(FORM_CONTROL_SELECTOR)) {
         return;
       }
 

--- a/package/src/JsonTree.tsx
+++ b/package/src/JsonTree.tsx
@@ -634,6 +634,7 @@ function renderJSONNode(
                 <JsonTreeValueEditor
                   value={value}
                   type={type}
+                  label={key ?? path}
                   editorProps={ctx.editorProps}
                   validate={(next) => ctx.validateNode?.(jsonNode, next) ?? null}
                   onCommit={(next) => ctx.onCommitEdit?.(jsonNode, next)}

--- a/package/src/JsonTree.tsx
+++ b/package/src/JsonTree.tsx
@@ -41,6 +41,8 @@ import {
 } from '@tabler/icons-react';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { JsonTreeMediaVariables } from './JsonTreeMediaVariables';
+import { JsonTreeValueEditor } from './JsonTreeValueEditor';
+import { setValueAtPath, type JsonTreePathSegments } from './lib/path';
 import {
   convertToTreeData,
   filterTreeBySearch,
@@ -76,7 +78,8 @@ export type JsonTreeStylesNames =
   | 'itemsCount'
   | 'indentGuide'
   | 'copyButton'
-  | 'lineNumber';
+  | 'lineNumber'
+  | 'valueEditor';
 
 export type JsonTreeCssVariables = {
   root: '--json-tree-font-family' | '--json-tree-font-size';
@@ -97,7 +100,8 @@ export type JsonTreeCssVariables = {
     | '--json-tree-color-regexp'
     | '--json-tree-color-map'
     | '--json-tree-color-set'
-    | '--json-tree-color-circular';
+    | '--json-tree-color-circular'
+    | '--json-tree-color-editable-outline';
   bracket: '--json-tree-color-bracket';
   indentGuide:
     | '--json-tree-indent-guide-color-0'
@@ -120,6 +124,7 @@ export type JsonTreeCssVariables = {
   searchBar: never;
   searchInput: never;
   searchHighlight: '--json-tree-search-highlight-color';
+  valueEditor: never;
 };
 
 export interface JsonTreeBaseProps {
@@ -266,10 +271,72 @@ export interface JsonTreeBaseProps {
    * ```
    */
   searchInputProps?: Omit<TextInputProps, 'value' | 'defaultValue' | 'onChange'>;
+
+  /**
+   * Whether primitive values can be edited in place.
+   *
+   * `JsonTree` is controlled while editing: it never holds a copy of your data,
+   * so `onChange` must be wired up and its value fed back through `data` for an
+   * edit to stick.
+   *
+   * @default false
+   */
+  editable?: boolean;
+
+  /**
+   * Called after a value is committed, with the next data and a description of
+   * what changed. The original object is never mutated: only the spine down to
+   * the edited node is rebuilt, so `Date`, `Map`, `Set`, `RegExp`, `BigInt`,
+   * functions and React elements elsewhere in the tree keep their identity.
+   */
+  onChange?: (value: unknown, change: JsonTreeChange) => void;
+
+  /**
+   * Which value types are editable.
+   *
+   * Everything outside this list stays read-only, which is why `Map` and `Set`
+   * entries can never be edited: their keys are synthetic (a `Map` key can be
+   * any value at all) and so cannot be addressed for a write.
+   *
+   * @default ['string', 'number', 'boolean']
+   */
+  editableTypes?: JsonTreeEditableType[];
+
+  /** Return `false` to keep an individual node read-only while `editable` is on */
+  isEditable?: (payload: JsonTreeNodePayload) => boolean;
+
+  /** Return an error message to reject an edit, or `null` to accept it */
+  validate?: (payload: JsonTreeNodePayload) => string | null;
+
+  /** Props forwarded to the inline editor input */
+  editorProps?: Record<string, unknown>;
 }
 
 /** Display mode for functions in JSON data */
 export type JsonTreeFunctionDisplay = 'as-string' | 'hide' | 'as-object';
+
+/** Value types that in-place editing can handle */
+export type JsonTreeEditableType = 'string' | 'number' | 'boolean';
+
+/** Everything known about the node an editing callback is being asked about */
+export interface JsonTreeNodePayload {
+  /** Display path, e.g. `root.address.city`. Not unique — see `pathSegments` */
+  path: string;
+  /** The node's address, one step per level. Object keys are strings, array indices numbers */
+  pathSegments: JsonTreePathSegments;
+  /** The key this value is stored under, absent on the root */
+  key?: string;
+  /** The node's value type */
+  type: ValueType;
+  /** The node's current value */
+  value: unknown;
+}
+
+/** Describes a committed edit */
+export interface JsonTreeChange extends JsonTreeNodePayload {
+  /** The value the node held before the edit */
+  previousValue: unknown;
+}
 
 export interface JsonTreeProps
   extends BoxProps, JsonTreeBaseProps, StylesApiProps<JsonTreeFactory> {}
@@ -305,6 +372,8 @@ export const defaultProps: Partial<JsonTreeProps> = {
   searchIcon: <IconSearch size={16} />,
   searchPlaceholder: 'Filter keys and values...',
   searchDebounce: 300,
+  editable: false,
+  editableTypes: ['string', 'number', 'boolean'],
 };
 
 interface RenderNodeContext {
@@ -318,6 +387,14 @@ interface RenderNodeContext {
   searchQuery?: string;
   matchedPaths?: Set<string>;
   directMatches?: Set<string>;
+  /** Serialized segments of the node currently being edited, if any */
+  editingKey?: string | null;
+  onStartEdit?: (key: string) => void;
+  onCommitEdit?: (node: JSONTreeNodeData, value: unknown) => void;
+  onCancelEdit?: () => void;
+  isNodeEditable?: (node: JSONTreeNodeData) => boolean;
+  validateNode?: (node: JSONTreeNodeData, value: unknown) => string | null;
+  editorProps?: Record<string, unknown>;
 }
 
 function highlightText(
@@ -416,6 +493,7 @@ function renderJSONNode(
     path,
     itemCount,
     depth = 0,
+    pathSegments,
   } = jsonNode.nodeData || {
     type: 'null' as ValueType,
     value: null,
@@ -537,8 +615,48 @@ function renderJSONNode(
         )}
         {(() => {
           const formattedValue = formatValue(value, type);
+          // Segments, not the display path: two different nodes can share a path
+          // string, and editing must never be ambiguous about which one it means.
+          const editKey = pathSegments ? JSON.stringify(pathSegments) : null;
+          const isEditable = editKey !== null && (ctx.isNodeEditable?.(jsonNode) ?? false);
+
+          if (isEditable && ctx.editingKey === editKey) {
+            return (
+              <Box {...getStyles('valueEditor')}>
+                <JsonTreeValueEditor
+                  value={value}
+                  type={type}
+                  editorProps={ctx.editorProps}
+                  validate={(next) => ctx.validateNode?.(jsonNode, next) ?? null}
+                  onCommit={(next) => ctx.onCommitEdit?.(jsonNode, next)}
+                  onCancel={() => ctx.onCancelEdit?.()}
+                />
+              </Box>
+            );
+          }
+
           return (
-            <Code {...getStyles('value')} data-type={type} data-value={formattedValue}>
+            <Code
+              {...getStyles('value')}
+              data-type={type}
+              data-value={formattedValue}
+              data-editable={isEditable || undefined}
+              data-edit-key={isEditable ? editKey : undefined}
+              onClick={
+                isEditable
+                  ? (event: React.MouseEvent) => {
+                      event.stopPropagation();
+                      if (type === 'boolean') {
+                        // a boolean has exactly one other state, so there is
+                        // nothing to type: toggle it and skip the editor
+                        ctx.onCommitEdit?.(jsonNode, !value);
+                        return;
+                      }
+                      ctx.onStartEdit?.(editKey);
+                    }
+                  : undefined
+              }
+            >
               {ctx.searchQuery
                 ? highlightText(formattedValue, ctx.searchQuery, getStyles)
                 : formattedValue}
@@ -691,6 +809,7 @@ const varsResolver = createVarsResolver<JsonTreeFactory>(
         '--json-tree-color-map': 'var(--mantine-color-grape-7)',
         '--json-tree-color-set': 'var(--mantine-color-grape-7)',
         '--json-tree-color-circular': 'var(--mantine-color-red-6)',
+        '--json-tree-color-editable-outline': 'var(--mantine-color-blue-5)',
       },
       bracket: { '--json-tree-color-bracket': 'var(--mantine-color-gray-5)' },
       indentGuide: {
@@ -717,6 +836,7 @@ const varsResolver = createVarsResolver<JsonTreeFactory>(
       searchHighlight: {
         '--json-tree-search-highlight-color': 'var(--mantine-color-yellow-3)',
       },
+      valueEditor: {},
     };
   }
 );
@@ -767,6 +887,12 @@ export const JsonTree = factory<JsonTreeFactory>((_props) => {
     onSearchChange,
     searchDebounce,
     searchInputProps,
+    editable,
+    onChange,
+    editableTypes,
+    isEditable,
+    validate,
+    editorProps,
 
     classNames,
     style,
@@ -845,9 +971,104 @@ export const JsonTree = factory<JsonTreeFactory>((_props) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- tree.setExpandedState changes on every render; using tree would cause infinite loop
   }, [controlledExpanded]);
 
+  // Editing state. Only the address of the node being edited lives here — the
+  // draft value stays inside the editor, so typing never re-renders the tree.
+  const [editingKey, setEditingKey] = useState<string | null>(null);
+
+  const nodePayload = useCallback((node: JSONTreeNodeData): JsonTreeNodePayload | null => {
+    const nd = node.nodeData;
+    if (!nd?.pathSegments) {
+      return null;
+    }
+    return {
+      path: nd.path,
+      pathSegments: nd.pathSegments,
+      key: nd.key,
+      type: nd.type,
+      value: nd.value,
+    };
+  }, []);
+
+  const isNodeEditable = useCallback(
+    (node: JSONTreeNodeData) => {
+      if (!editable) {
+        return false;
+      }
+      const payload = nodePayload(node);
+      if (!payload) {
+        // Map and Set entries, and function properties expanded as an object,
+        // have no address that could be written back
+        return false;
+      }
+      if (!(editableTypes ?? []).includes(payload.type as JsonTreeEditableType)) {
+        return false;
+      }
+      return isEditable?.(payload) ?? true;
+    },
+    [editable, editableTypes, isEditable, nodePayload]
+  );
+
+  const validateNode = useCallback(
+    (node: JSONTreeNodeData, nextValue: unknown) => {
+      if (!validate) {
+        return null;
+      }
+      const payload = nodePayload(node);
+      return payload ? validate({ ...payload, value: nextValue }) : null;
+    },
+    [validate, nodePayload]
+  );
+
+  const handleCommitEdit = useCallback(
+    (node: JSONTreeNodeData, nextValue: unknown) => {
+      setEditingKey(null);
+
+      const payload = nodePayload(node);
+      if (!payload || Object.is(payload.value, nextValue)) {
+        return;
+      }
+
+      const nextData = setValueAtPath(data, payload.pathSegments, nextValue);
+      onChange?.(nextData, { ...payload, value: nextValue, previousValue: payload.value });
+    },
+    [data, onChange, nodePayload]
+  );
+
+  const handleCancelEdit = useCallback(() => setEditingKey(null), []);
+
+  useEffect(() => {
+    // The most likely way to get this wrong is to switch `editable` on and see
+    // edits silently revert: JsonTree is controlled and holds no copy of the data.
+    if (process.env.NODE_ENV !== 'production' && editable && !onChange) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'JsonTree: `editable` is set but `onChange` is missing, so edits cannot be kept. ' +
+          'JsonTree does not hold its own copy of the data — feed the value from `onChange` back through `data`.'
+      );
+    }
+  }, [editable, onChange]);
+
   // Keyboard handler for Ctrl+C copy on focused node
   const handleKeyDown = useCallback(
     async (e: React.KeyboardEvent) => {
+      // Enter edits the focused row. Routing it through the cell's own click
+      // keeps one code path for mouse and keyboard — and, more importantly,
+      // avoids giving every value its own tab stop just to be reachable.
+      if (editable && e.key === 'Enter' && !e.metaKey && !e.ctrlKey && !e.altKey) {
+        const row = (document.activeElement as HTMLElement | null)?.closest?.('[role="treeitem"]');
+        if (row && (e.currentTarget as HTMLElement).contains(row)) {
+          const cell = Array.from(row.querySelectorAll<HTMLElement>('[data-edit-key]')).find(
+            // querySelectorAll reaches into nested rows; keep only this row's own cell
+            (el) => el.closest('[role="treeitem"]') === row
+          );
+          if (cell) {
+            e.preventDefault();
+            cell.click();
+            return;
+          }
+        }
+      }
+
       if (!withCopyToClipboard || !(e.metaKey || e.ctrlKey) || e.key !== 'c') {
         return;
       }
@@ -896,7 +1117,7 @@ export const JsonTree = factory<JsonTreeFactory>((_props) => {
         // Clipboard write may fail silently in unsupported contexts
       }
     },
-    [withCopyToClipboard, treeData, onCopy]
+    [withCopyToClipboard, treeData, onCopy, editable]
   );
 
   // Key count for badge
@@ -1008,6 +1229,13 @@ export const JsonTree = factory<JsonTreeFactory>((_props) => {
     searchQuery: debouncedQuery || undefined,
     matchedPaths: debouncedQuery ? searchResults.matchedPaths : undefined,
     directMatches: debouncedQuery ? searchResults.directMatches : undefined,
+    editingKey,
+    onStartEdit: setEditingKey,
+    onCommitEdit: handleCommitEdit,
+    onCancelEdit: handleCancelEdit,
+    isNodeEditable,
+    validateNode,
+    editorProps,
   };
 
   const treeComponent = (

--- a/package/src/JsonTree.tsx
+++ b/package/src/JsonTree.tsx
@@ -41,7 +41,7 @@ import {
 } from '@tabler/icons-react';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { JsonTreeMediaVariables } from './JsonTreeMediaVariables';
-import { JsonTreeValueEditor } from './JsonTreeValueEditor';
+import { JsonTreeValueEditor, type JsonTreeEditorProps } from './JsonTreeValueEditor';
 import { setValueAtPath, type JsonTreePathSegments } from './lib/path';
 import {
   convertToTreeData,
@@ -309,7 +309,7 @@ export interface JsonTreeBaseProps {
   validate?: (payload: JsonTreeNodePayload) => string | null;
 
   /** Props forwarded to the inline editor input */
-  editorProps?: Record<string, unknown>;
+  editorProps?: JsonTreeEditorProps;
 }
 
 /** Display mode for functions in JSON data */
@@ -389,12 +389,12 @@ interface RenderNodeContext {
   directMatches?: Set<string>;
   /** Serialized segments of the node currently being edited, if any */
   editingKey?: string | null;
-  onStartEdit?: (key: string) => void;
+  onStartEdit?: (key: string, row: HTMLElement | null) => void;
   onCommitEdit?: (node: JSONTreeNodeData, value: unknown) => void;
   onCancelEdit?: () => void;
   isNodeEditable?: (node: JSONTreeNodeData) => boolean;
   validateNode?: (node: JSONTreeNodeData, value: unknown) => string | null;
-  editorProps?: Record<string, unknown>;
+  editorProps?: JsonTreeEditorProps;
 }
 
 function highlightText(
@@ -652,7 +652,10 @@ function renderJSONNode(
                         ctx.onCommitEdit?.(jsonNode, !value);
                         return;
                       }
-                      ctx.onStartEdit?.(editKey);
+                      ctx.onStartEdit?.(
+                        editKey,
+                        event.currentTarget.closest<HTMLElement>('[role="treeitem"]')
+                      );
                     }
                   : undefined
               }
@@ -976,6 +979,26 @@ export const JsonTree = factory<JsonTreeFactory>((_props) => {
   // Editing state. Only the address of the node being edited lives here — the
   // draft value stays inside the editor, so typing never re-renders the tree.
   const [editingKey, setEditingKey] = useState<string | null>(null);
+  // The row that owns the open editor. When the editor unmounts its input goes
+  // with it and focus falls to the body, which drops a keyboard user out of the
+  // tree entirely — arrow navigation stops working until they tab back in.
+  const editingRowRef = useRef<HTMLElement | null>(null);
+
+  const handleStartEdit = useCallback((key: string, row: HTMLElement | null) => {
+    editingRowRef.current = row;
+    setEditingKey(key);
+  }, []);
+
+  useEffect(() => {
+    if (editingKey !== null) {
+      return;
+    }
+    const row = editingRowRef.current;
+    editingRowRef.current = null;
+    if (row?.isConnected) {
+      row.focus();
+    }
+  }, [editingKey]);
 
   const nodePayload = useCallback((node: JSONTreeNodeData): JsonTreeNodePayload | null => {
     const nd = node.nodeData;
@@ -1232,7 +1255,7 @@ export const JsonTree = factory<JsonTreeFactory>((_props) => {
     matchedPaths: debouncedQuery ? searchResults.matchedPaths : undefined,
     directMatches: debouncedQuery ? searchResults.directMatches : undefined,
     editingKey,
-    onStartEdit: setEditingKey,
+    onStartEdit: handleStartEdit,
     onCommitEdit: handleCommitEdit,
     onCancelEdit: handleCancelEdit,
     isNodeEditable,

--- a/package/src/JsonTree.tsx
+++ b/package/src/JsonTree.tsx
@@ -780,7 +780,7 @@ function renderJSONNode(
 }
 
 const varsResolver = createVarsResolver<JsonTreeFactory>(
-  (_, { stickyHeader, stickyHeaderOffset }) => {
+  (_, { stickyHeader, stickyHeaderOffset, editable }) => {
     return {
       root: {
         '--json-tree-font-family': 'var(--mantine-font-family-monospace)',
@@ -809,7 +809,9 @@ const varsResolver = createVarsResolver<JsonTreeFactory>(
         '--json-tree-color-map': 'var(--mantine-color-grape-7)',
         '--json-tree-color-set': 'var(--mantine-color-grape-7)',
         '--json-tree-color-circular': 'var(--mantine-color-red-6)',
-        '--json-tree-color-editable-outline': 'var(--mantine-color-blue-5)',
+        // Only emitted when editing is on. Mantine drops `undefined` vars, so a
+        // read-only tree renders exactly the markup it did before this prop existed.
+        '--json-tree-color-editable-outline': editable ? 'var(--mantine-color-blue-5)' : undefined,
       },
       bracket: { '--json-tree-color-bracket': 'var(--mantine-color-gray-5)' },
       indentGuide: {

--- a/package/src/JsonTreeValueEditor.tsx
+++ b/package/src/JsonTreeValueEditor.tsx
@@ -31,6 +31,9 @@ export interface JsonTreeValueEditorProps {
 
   /** Props forwarded to the input */
   editorProps?: JsonTreeEditorProps;
+
+  /** The key being edited, used to name the field for assistive technology */
+  label?: string;
 }
 
 /**
@@ -53,6 +56,7 @@ export function JsonTreeValueEditor({
   onCancel,
   validate,
   editorProps,
+  label,
 }: JsonTreeValueEditorProps) {
   const [draft, setDraft] = useState<string | number>(() =>
     type === 'number' ? (value as number) : String(value ?? '')
@@ -120,6 +124,10 @@ export function JsonTreeValueEditor({
   // exactly the failure the guard exists to prevent.
   const shared = {
     ...editorProps,
+    // Without a name, assistive technology announces an empty edit field with no
+    // clue which key it belongs to. Derived from the data's own key, so the only
+    // English in it is the verb — and a consumer can still override it.
+    'aria-label': editorProps?.['aria-label'] ?? (label ? `Edit ${label}` : 'Edit value'),
     autoFocus: true,
     error,
     size: editorProps?.size ?? ('xs' as const),

--- a/package/src/JsonTreeValueEditor.tsx
+++ b/package/src/JsonTreeValueEditor.tsx
@@ -1,0 +1,132 @@
+import { NumberInput, TextInput } from '@mantine/core';
+import React, { useRef, useState } from 'react';
+import type { ValueType } from './lib/utils';
+
+export interface JsonTreeValueEditorProps {
+  /** The value being edited */
+  value: unknown;
+
+  /** Its type, which decides the input to render */
+  type: ValueType;
+
+  /** Called with the parsed value when the edit is accepted */
+  onCommit: (value: unknown) => void;
+
+  /** Called when the edit is abandoned */
+  onCancel: () => void;
+
+  /** Returns an error message to reject the value, or null to accept it */
+  validate?: (value: unknown) => string | null;
+
+  /** Styles API props for the input */
+  editorProps?: Record<string, unknown>;
+}
+
+/**
+ * The inline editor for a primitive value.
+ *
+ * The draft lives here rather than in `JsonTree` on purpose: a keystroke must
+ * not re-render the whole tree, so nothing leaves this component until the edit
+ * is committed.
+ *
+ * Every pointer and keyboard event is stopped before it leaves. Mantine's Tree
+ * puts its keyboard navigation on the `li[role="treeitem"]` and calls
+ * `preventDefault()` on the arrow keys and on Space (`expandOnSpace` defaults to
+ * true), so without this the caret cannot move and a space cannot be typed —
+ * verified, the field simply stays empty.
+ */
+export function JsonTreeValueEditor({
+  value,
+  type,
+  onCommit,
+  onCancel,
+  validate,
+  editorProps,
+}: JsonTreeValueEditorProps) {
+  const [draft, setDraft] = useState<string | number>(() =>
+    type === 'number' ? (value as number) : String(value ?? '')
+  );
+  const [error, setError] = useState<string | null>(null);
+  // a commit triggered by Enter must not run again when the field then blurs
+  const committedRef = useRef(false);
+
+  const parse = (): unknown => (type === 'number' ? Number(draft) : String(draft));
+
+  const commit = () => {
+    if (committedRef.current) {
+      return;
+    }
+
+    const next = parse();
+
+    if (type === 'number' && !Number.isFinite(next as number)) {
+      setError('Not a number');
+      return;
+    }
+
+    const validationError = validate?.(next) ?? null;
+    if (validationError !== null) {
+      setError(validationError);
+      return;
+    }
+
+    committedRef.current = true;
+    onCommit(next);
+  };
+
+  const cancel = () => {
+    committedRef.current = true;
+    onCancel();
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    // Tree owns arrows and Space on the row above; keep them in the field
+    event.stopPropagation();
+
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      commit();
+    }
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      cancel();
+    }
+  };
+
+  const shared = {
+    autoFocus: true,
+    error,
+    size: 'xs' as const,
+    onKeyDown: handleKeyDown,
+    onClick: (event: React.MouseEvent) => event.stopPropagation(),
+    onMouseDown: (event: React.MouseEvent) => event.stopPropagation(),
+    onBlur: commit,
+    ...editorProps,
+  };
+
+  if (type === 'number') {
+    return (
+      <NumberInput
+        {...shared}
+        value={draft}
+        onChange={(next) => {
+          setError(null);
+          setDraft(next);
+        }}
+      />
+    );
+  }
+
+  return (
+    <TextInput
+      {...shared}
+      value={String(draft)}
+      onChange={(event) => {
+        setError(null);
+        setDraft(event.currentTarget.value);
+      }}
+    />
+  );
+}
+
+JsonTreeValueEditor.displayName = 'JsonTreeValueEditor';

--- a/package/src/JsonTreeValueEditor.tsx
+++ b/package/src/JsonTreeValueEditor.tsx
@@ -1,6 +1,17 @@
-import { NumberInput, TextInput } from '@mantine/core';
+import { NumberInput, TextInput, type NumberInputProps, type TextInputProps } from '@mantine/core';
 import React, { useRef, useState } from 'react';
 import type { ValueType } from './lib/utils';
+
+/**
+ * Props forwarded to the inline editor input.
+ *
+ * The props the editor owns are excluded: `value`, `defaultValue` and `onChange`
+ * drive the draft, and `error` carries the validation message.
+ */
+export type JsonTreeEditorProps = Omit<
+  TextInputProps & NumberInputProps,
+  'value' | 'defaultValue' | 'onChange' | 'error'
+>;
 
 export interface JsonTreeValueEditorProps {
   /** The value being edited */
@@ -18,8 +29,8 @@ export interface JsonTreeValueEditorProps {
   /** Returns an error message to reject the value, or null to accept it */
   validate?: (value: unknown) => string | null;
 
-  /** Styles API props for the input */
-  editorProps?: Record<string, unknown>;
+  /** Props forwarded to the input */
+  editorProps?: JsonTreeEditorProps;
 }
 
 /**
@@ -55,6 +66,15 @@ export function JsonTreeValueEditor({
   const commit = () => {
     if (committedRef.current) {
       return;
+    }
+
+    if (type === 'number') {
+      // NumberInput reports an empty field as '', and Number('') is 0 — committing
+      // that would write a zero the user never typed while trying to clear it
+      if (draft === '' || draft === null || draft === undefined) {
+        setError('Required');
+        return;
+      }
     }
 
     const next = parse();
@@ -93,15 +113,32 @@ export function JsonTreeValueEditor({
     }
   };
 
+  // `editorProps` is spread first, and the editor's own handlers then wrap the
+  // consumer's rather than being replaced by them. Spreading it last let a
+  // consumer `onKeyDown` overwrite the guard above, at which point Mantine's Tree
+  // reclaims the arrow keys and Space and the field stops accepting spaces —
+  // exactly the failure the guard exists to prevent.
   const shared = {
+    ...editorProps,
     autoFocus: true,
     error,
-    size: 'xs' as const,
-    onKeyDown: handleKeyDown,
-    onClick: (event: React.MouseEvent) => event.stopPropagation(),
-    onMouseDown: (event: React.MouseEvent) => event.stopPropagation(),
-    onBlur: commit,
-    ...editorProps,
+    size: editorProps?.size ?? ('xs' as const),
+    onKeyDown: (event: React.KeyboardEvent) => {
+      editorProps?.onKeyDown?.(event as React.KeyboardEvent<HTMLInputElement>);
+      handleKeyDown(event);
+    },
+    onClick: (event: React.MouseEvent) => {
+      editorProps?.onClick?.(event as React.MouseEvent<HTMLInputElement>);
+      event.stopPropagation();
+    },
+    onMouseDown: (event: React.MouseEvent) => {
+      editorProps?.onMouseDown?.(event as React.MouseEvent<HTMLInputElement>);
+      event.stopPropagation();
+    },
+    onBlur: (event: React.FocusEvent) => {
+      editorProps?.onBlur?.(event as React.FocusEvent<HTMLInputElement>);
+      commit();
+    },
   };
 
   if (type === 'number') {

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -1,10 +1,14 @@
 export { JsonTree } from './JsonTree';
 export type {
   JsonTreeBaseProps,
+  JsonTreeChange,
   JsonTreeCssVariables,
+  JsonTreeEditableType,
   JsonTreeFactory,
   JsonTreeFunctionDisplay,
+  JsonTreeNodePayload,
   JsonTreeProps,
   JsonTreeStylesNames,
 } from './JsonTree';
+export type { JsonTreePathSegments } from './lib/path';
 export type { JSONTreeNodeData, ValueType } from './lib/utils';

--- a/package/src/lib/path.test.ts
+++ b/package/src/lib/path.test.ts
@@ -1,0 +1,128 @@
+import { getValueAtPath, setValueAtPath } from './path';
+
+describe('setValueAtPath', () => {
+  it('replaces the root when there are no segments', () => {
+    expect(setValueAtPath({ a: 1 }, [], 'replaced')).toBe('replaced');
+  });
+
+  it('writes a top-level key without mutating the original', () => {
+    const original = { name: 'John', age: 30 };
+    const next = setValueAtPath(original, ['name'], 'Jane');
+
+    expect(next).toEqual({ name: 'Jane', age: 30 });
+    expect(original).toEqual({ name: 'John', age: 30 });
+    expect(next).not.toBe(original);
+  });
+
+  it('writes a nested key', () => {
+    const original = { address: { city: 'Anytown', zip: '12345' } };
+    const next = setValueAtPath(original, ['address', 'city'], 'Springfield');
+
+    expect(next.address.city).toBe('Springfield');
+    expect(next.address.zip).toBe('12345');
+    expect(original.address.city).toBe('Anytown');
+  });
+
+  it('writes an array index', () => {
+    const original = { courses: ['html', 'css', 'js'] };
+    const next = setValueAtPath(original, ['courses', 1], 'scss');
+
+    expect(next.courses).toEqual(['html', 'scss', 'js']);
+    expect(original.courses).toEqual(['html', 'css', 'js']);
+    expect(Array.isArray(next.courses)).toBe(true);
+  });
+
+  it('clones only the spine, leaving untouched branches identical', () => {
+    const untouched = { deep: { value: 1 } };
+    const original = { a: { b: { c: 'old' } }, untouched };
+    const next = setValueAtPath(original, ['a', 'b', 'c'], 'new');
+
+    // rewritten spine is fresh
+    expect(next).not.toBe(original);
+    expect(next.a).not.toBe(original.a);
+    expect(next.a.b).not.toBe(original.a.b);
+    // everything else is carried over by reference
+    expect(next.untouched).toBe(untouched);
+  });
+
+  it('carries non-JSON values across by reference', () => {
+    const date = new Date('2024-01-15T10:30:00Z');
+    const map = new Map([['k', 'v']]);
+    const set = new Set([1, 2]);
+    const regexp = /pattern/gi;
+    const fn = function handleClick() {};
+    const big = BigInt(9007199254740991);
+    const sym = Symbol.for('app.config');
+
+    const original = { edit: 'before', date, map, set, regexp, fn, big, sym };
+    const next = setValueAtPath(original, ['edit'], 'after');
+
+    expect(next.edit).toBe('after');
+    // identity, not equality: a structuredClone or JSON round-trip would break these
+    expect(next.date).toBe(date);
+    expect(next.map).toBe(map);
+    expect(next.set).toBe(set);
+    expect(next.regexp).toBe(regexp);
+    expect(next.fn).toBe(fn);
+    expect(next.big).toBe(big);
+    expect(next.sym).toBe(sym);
+  });
+
+  it('keeps a special type intact when it sits on the spine below the target', () => {
+    const date = new Date('2024-01-15T10:30:00Z');
+    const original = { meta: { label: 'old', createdAt: date } };
+    const next = setValueAtPath(original, ['meta', 'label'], 'new');
+
+    expect(next.meta.label).toBe('new');
+    expect(next.meta.createdAt).toBe(date);
+    expect(next.meta.createdAt instanceof Date).toBe(true);
+  });
+
+  it('tells a dotted key apart from a nested object', () => {
+    // both render at the string path "root.a.b" — segments are what disambiguate
+    const dotted = setValueAtPath({ 'a.b': 1, a: { b: 2 } }, ['a.b'], 'X');
+    expect(dotted).toEqual({ 'a.b': 'X', a: { b: 2 } });
+
+    const nested = setValueAtPath({ 'a.b': 1, a: { b: 2 } }, ['a', 'b'], 'Y');
+    expect(nested).toEqual({ 'a.b': 1, a: { b: 'Y' } });
+  });
+
+  it('tells an array index apart from a numeric object key', () => {
+    const arr = setValueAtPath({ x: ['v'] }, ['x', 0], 'W');
+    expect(arr).toEqual({ x: ['W'] });
+    expect(Array.isArray(arr.x)).toBe(true);
+
+    const obj = setValueAtPath({ x: { 0: 'v' } }, ['x', '0'], 'W');
+    expect(obj).toEqual({ x: { 0: 'W' } });
+    expect(Array.isArray(obj.x)).toBe(false);
+  });
+
+  it('refuses to write where the address does not resolve', () => {
+    expect(() => setValueAtPath({ a: 1 }, ['missing'], 'x')).toThrow(/does not exist/);
+    expect(() => setValueAtPath({ a: [1] }, ['a', 5], 'x')).toThrow(/out of range/);
+    expect(() => setValueAtPath({ a: 'plain' }, ['a', 'b'], 'x')).toThrow(/not a plain object/);
+  });
+
+  it('refuses to write into a Map or a Set', () => {
+    // their entries have no unambiguous segment: a Map key can be any value
+    expect(() => setValueAtPath({ m: new Map([['k', 'v']]) }, ['m', 'k'], 'x')).toThrow(
+      /not a plain object/
+    );
+    expect(() => setValueAtPath({ s: new Set(['v']) }, ['s', 0], 'x')).toThrow(
+      /not a plain object/
+    );
+  });
+});
+
+describe('getValueAtPath', () => {
+  it('reads nested values', () => {
+    const data = { a: { b: ['x', 'y'] } };
+    expect(getValueAtPath(data, ['a', 'b', 1])).toBe('y');
+    expect(getValueAtPath(data, [])).toBe(data);
+  });
+
+  it('returns undefined for an address that does not resolve', () => {
+    expect(getValueAtPath({ a: 1 }, ['a', 'b'])).toBeUndefined();
+    expect(getValueAtPath({ a: 1 }, ['nope'])).toBeUndefined();
+  });
+});

--- a/package/src/lib/path.ts
+++ b/package/src/lib/path.ts
@@ -17,7 +17,7 @@ export type JsonTreePathSegments = readonly (string | number)[];
  * key can be any value at all, including an object), so there is no segment
  * that could address them unambiguously.
  */
-function isWritableContainer(value: unknown): value is Record<string, unknown> | unknown[] {
+export function isWritableContainer(value: unknown): value is Record<string, unknown> | unknown[] {
   if (Array.isArray(value)) {
     return true;
   }

--- a/package/src/lib/path.ts
+++ b/package/src/lib/path.ts
@@ -1,0 +1,92 @@
+/**
+ * A resolved address inside the tree.
+ *
+ * The `path` string that `JsonTree` has always exposed is built by joining keys
+ * with dots, which makes it a fine label and a poor address: `{ 'a.b': 1 }` and
+ * `{ a: { b: 1 } }` both produce `root.a.b`, and an array index is
+ * indistinguishable from an object key that happens to be numeric. Segments
+ * keep each step separate, so a write lands where it was aimed.
+ *
+ * Numbers address array indices, strings address object keys.
+ */
+export type JsonTreePathSegments = readonly (string | number)[];
+
+/**
+ * Containers a value can be written into. `Map` and `Set` are deliberately
+ * absent: their entries are rendered under a synthetic display key (a `Map`
+ * key can be any value at all, including an object), so there is no segment
+ * that could address them unambiguously.
+ */
+function isWritableContainer(value: unknown): value is Record<string, unknown> | unknown[] {
+  if (Array.isArray(value)) {
+    return true;
+  }
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+/**
+ * Return a copy of `root` with the value at `segments` replaced.
+ *
+ * Only the spine down to the target is cloned; every value hanging off it is
+ * carried over by reference. That is what keeps `Date`, `Map`, `Set`, `RegExp`,
+ * `BigInt`, functions and React elements intact — a `structuredClone` or a
+ * `JSON` round-trip would flatten or destroy all of them.
+ *
+ * Throws when the address does not resolve, rather than silently writing
+ * somewhere else: an unreachable path means the caller and the tree disagree
+ * about the shape of the data, and guessing would corrupt it.
+ */
+export function setValueAtPath<T>(root: T, segments: JsonTreePathSegments, value: unknown): T {
+  if (segments.length === 0) {
+    return value as T;
+  }
+
+  const [segment, ...rest] = segments;
+
+  if (!isWritableContainer(root)) {
+    throw new Error(
+      `JsonTree: cannot write to "${String(segment)}" — the value holding it is not a plain object or array.`
+    );
+  }
+
+  if (Array.isArray(root)) {
+    const index = typeof segment === 'number' ? segment : Number(segment);
+    if (!Number.isInteger(index) || index < 0 || index >= root.length) {
+      throw new Error(`JsonTree: index ${String(segment)} is out of range for this array.`);
+    }
+    const next: unknown[] = [...root];
+    next[index] = rest.length === 0 ? value : setValueAtPath(next[index], rest, value);
+    return next as T;
+  }
+
+  const key = String(segment);
+  if (!Object.hasOwn(root, key)) {
+    throw new Error(`JsonTree: key "${key}" does not exist on this object.`);
+  }
+  return {
+    ...root,
+    [key]: rest.length === 0 ? value : setValueAtPath(root[key], rest, value),
+  } as T;
+}
+
+/**
+ * Read the value at `segments`, or `undefined` when the address does not
+ * resolve. Used to hand callbacks the previous value without a second walk.
+ */
+export function getValueAtPath(root: unknown, segments: JsonTreePathSegments): unknown {
+  let current: unknown = root;
+  for (const segment of segments) {
+    if (Array.isArray(current)) {
+      current = current[typeof segment === 'number' ? segment : Number(segment)];
+    } else if (typeof current === 'object' && current !== null) {
+      current = (current as Record<string, unknown>)[String(segment)];
+    } else {
+      return undefined;
+    }
+  }
+  return current;
+}

--- a/package/src/lib/utils.tsx
+++ b/package/src/lib/utils.tsx
@@ -1,5 +1,6 @@
 import { type TreeNodeData } from '@mantine/core';
 import type { JsonTreeFunctionDisplay } from '../JsonTree';
+import type { JsonTreePathSegments } from './path';
 
 export interface JSONTreeNodeData extends TreeNodeData {
   nodeData?: {
@@ -9,6 +10,21 @@ export interface JSONTreeNodeData extends TreeNodeData {
     path: string;
     itemCount?: number;
     depth?: number;
+    /**
+     * The node's address as separate steps, or `undefined` when it has none.
+     *
+     * `path` is a display label — it joins keys with dots, so `{ 'a.b': 1 }` and
+     * `{ a: { b: 1 } }` collide on `root.a.b`, and an array index reads the same
+     * as a numeric object key. Segments keep the steps apart, which is what
+     * makes a write land where it was aimed.
+     *
+     * `undefined` marks a node that cannot be addressed at all: everything under
+     * a `Map` or `Set` (their entries are rendered under a synthetic display key)
+     * and everything under a function expanded via `displayFunctions:
+     * 'as-object'` (those properties belong to a synthetic object that does not
+     * exist in the data).
+     */
+    pathSegments?: JsonTreePathSegments;
   };
 }
 
@@ -280,9 +296,15 @@ export function convertToTreeData(
   path: string = 'root',
   depth: number = 0,
   displayFunctions: JsonTreeFunctionDisplay = 'as-string',
-  ancestors: readonly unknown[] = []
+  ancestors: readonly unknown[] = [],
+  // `null` marks an unaddressable subtree. It cannot be `undefined`: passing
+  // `undefined` to a parameter with a default re-triggers that default, which
+  // would silently hand every Map/Set child a valid-looking address.
+  segments: JsonTreePathSegments | null = []
 ): JSONTreeNodeData {
   const type = getValueType(value);
+  // `null` is the internal sentinel; the public shape uses `undefined`
+  const pathSegments = segments ?? undefined;
 
   // Guard against reference cycles, which would otherwise recurse until the
   // stack blows (`obj.self = obj` is routine in debug panels and object graphs).
@@ -293,7 +315,7 @@ export function convertToTreeData(
     return {
       value: path,
       label: key ?? path,
-      nodeData: { type: 'circular', value, key, path, depth },
+      nodeData: { type: 'circular', value, key, path, depth, pathSegments },
     };
   }
 
@@ -302,7 +324,7 @@ export function convertToTreeData(
     return {
       value: path,
       label: key ?? path,
-      nodeData: { type, value, key, path, depth },
+      nodeData: { type, value, key, path, depth, pathSegments },
     };
   }
 
@@ -318,7 +340,7 @@ export function convertToTreeData(
     return {
       value: path,
       label: key ?? path,
-      nodeData: { type, value, key, path, depth },
+      nodeData: { type, value, key, path, depth, pathSegments },
     };
   }
 
@@ -333,7 +355,7 @@ export function convertToTreeData(
       return {
         value: path,
         label: key ?? path,
-        nodeData: { type, value, key, path, depth },
+        nodeData: { type, value, key, path, depth, pathSegments },
       };
     }
     // displayFunctions === 'as-object': treat function as object to show its properties
@@ -344,10 +366,16 @@ export function convertToTreeData(
       },
       {} as Record<string, any>
     );
-    return convertToTreeData(functionProps, key, path, depth, displayFunctions, [
-      ...ancestors,
-      value,
-    ]);
+    return convertToTreeData(
+      functionProps,
+      key,
+      path,
+      depth,
+      displayFunctions,
+      [...ancestors, value],
+      // these properties belong to a synthetic object, so none of them is addressable
+      null
+    );
   }
 
   const expandable = isExpandable(value);
@@ -357,29 +385,48 @@ export function convertToTreeData(
     return {
       value: nodeValue,
       label: key ?? path,
-      nodeData: { type, value, key, path, depth },
+      nodeData: { type, value, key, path, depth, pathSegments },
     };
   }
 
-  let entries: [string, any][] = [];
+  // [display key, value, addressable segment]. The segment is `undefined` where
+  // the entry cannot be addressed: a Map key can be any value at all, and a Set
+  // has no keys, so their display keys are synthetic and cannot be written back.
+  let entries: [string, any, string | number | undefined][] = [];
   if (type === 'array') {
-    entries = value.map((item: any, index: number) => [String(index), item] as [string, any]);
+    entries = value.map(
+      (item: any, index: number) =>
+        [String(index), item, index] as [string, any, string | number | undefined]
+    );
   } else if (type === 'map') {
     entries = Array.from(value.entries() as Iterable<[any, any]>).map(
-      ([k, v]: [any, any], index: number) => [`[${index}] ${String(k)}`, v] as [string, any]
+      ([k, v]: [any, any], index: number) =>
+        [`[${index}] ${String(k)}`, v, undefined] as [string, any, string | number | undefined]
     );
   } else if (type === 'set') {
     entries = Array.from(value.values()).map(
-      (item: any, index: number) => [String(index), item] as [string, any]
+      (item: any, index: number) =>
+        [String(index), item, undefined] as [string, any, string | number | undefined]
     );
   } else {
-    entries = Object.entries(value);
+    entries = Object.entries(value).map(
+      ([k, v]) => [k, v, k] as [string, any, string | number | undefined]
+    );
   }
 
   const childAncestors = [...ancestors, value];
   const children = entries
-    .map(([k, v]) =>
-      convertToTreeData(v, k, `${path}.${k}`, depth + 1, displayFunctions, childAncestors)
+    .map(([k, v, segment]) =>
+      convertToTreeData(
+        v,
+        k,
+        `${path}.${k}`,
+        depth + 1,
+        displayFunctions,
+        childAncestors,
+        // an unaddressable step makes the whole subtree below it unaddressable
+        segments === null || segment === undefined ? null : [...segments, segment]
+      )
     )
     .filter((node) => node !== null); // Filter out hidden functions
 
@@ -387,7 +434,15 @@ export function convertToTreeData(
     value: nodeValue,
     label: key ?? path,
     children,
-    nodeData: { type, value, key, path, itemCount: getItemCount(value), depth },
+    nodeData: {
+      type,
+      value,
+      key,
+      path,
+      itemCount: getItemCount(value),
+      depth,
+      pathSegments,
+    },
   };
 }
 

--- a/package/src/lib/utils.tsx
+++ b/package/src/lib/utils.tsx
@@ -1,6 +1,6 @@
 import { type TreeNodeData } from '@mantine/core';
 import type { JsonTreeFunctionDisplay } from '../JsonTree';
-import type { JsonTreePathSegments } from './path';
+import { isWritableContainer, type JsonTreePathSegments } from './path';
 
 export interface JSONTreeNodeData extends TreeNodeData {
   nodeData?: {
@@ -415,6 +415,11 @@ export function convertToTreeData(
   }
 
   const childAncestors = [...ancestors, value];
+  // Only a plain object or an array can be written into. A class instance is
+  // rendered as an object and would otherwise hand its properties an address
+  // that setValueAtPath refuses — the two rules have to agree, or an edit
+  // throws at commit time instead of never being offered.
+  const childrenAddressable = isWritableContainer(value);
   const children = entries
     .map(([k, v, segment]) =>
       convertToTreeData(
@@ -425,7 +430,9 @@ export function convertToTreeData(
         displayFunctions,
         childAncestors,
         // an unaddressable step makes the whole subtree below it unaddressable
-        segments === null || segment === undefined ? null : [...segments, segment]
+        segments === null || segment === undefined || !childrenAddressable
+          ? null
+          : [...segments, segment]
       )
     )
     .filter((node) => node !== null); // Filter out hidden functions


### PR DESCRIPTION
Implements the ask in #22, at the size the person who asked for it described.

> @gfazioli I have an use-case where (in-place) editing values would be very helpful. At this moment, I'm not so interested in renaming / adding / re-organizing keys. Being able to just edit the value of an existing key would already be very helpful.
> — @brocaar

So: values only. Renaming keys, adding, removing and reordering are deliberately out — the last section explains why that is not simply "less work".

## What it does

Opt-in via `editable`, default off. The read-only render path is untouched.

- Click a **string** or **number** → inline editor. `Enter` commits, `Escape` cancels, blur commits.
- Click a **boolean** → toggles outright. It has exactly one other state, so there is nothing to type.
- `Enter` on a focused row opens its editor, so the whole flow works from the keyboard — **without adding a tab stop per value**, which would make a large tree impossible to tab past. There is a test asserting the cells carry no `tabindex`.

```tsx
const [data, setData] = useState(initial);

<JsonTree
  data={data}
  editable
  onChange={(next, change) => setData(next)}
  editableTypes={['string', 'number', 'boolean']}   // the default
  isEditable={({ path }) => path !== 'root.id'}
  validate={({ value }) => (String(value).trim() === '' ? 'Cannot be empty' : null)}
/>
```

`JsonTree` stays **controlled** — it holds no copy of your data, and `onChange` only takes effect once fed back through `data`. A dev-only warning says so when `editable` is set without `onChange`, which is the easy way to get this wrong.

## Two things had to be solved first

### 1. The paths were not addresses

`path` joins keys with dots, so `{ 'a.b': 1 }` and `{ a: { b: 1 } }` **both render at `root.a.b`**, and an array index is indistinguishable from a numeric object key. Fine as a label; unusable as the target of a write.

Nodes now carry `pathSegments` alongside it — one step per level, object keys as strings, array indices as numbers — and every write goes through those. `path` is unchanged, so `onNodeClick`, `showPathOnHover` and stored `expanded` arrays keep working exactly as before.

`pathSegments` is `undefined` where no address exists, and those nodes can never be edited whatever `editableTypes` says:

- **under a `Map` or `Set`** — their display keys are synthetic, and a `Map` key can be any value at all, including an object;
- **under a function expanded with `displayFunctions="as-object"`** — those properties belong to a synthetic object that is not in your data.

One bug worth recording: the internal sentinel for "unaddressable" is `null`, not `undefined`, because **passing `undefined` to a parameter with a default re-triggers that default** — which silently handed every `Map` child a valid-looking address. The tests caught it before anything was wired up.

### 2. Mantine's Tree fights inline inputs

`TreeNode` puts keyboard navigation on the `li[role="treeitem"]` and calls `preventDefault()` on the arrow keys and on **Space** (`expandOnSpace` defaults to `true`). A field inside a node therefore cannot take a space and its caret cannot move — verified before writing any of this: the input simply stays empty.

The editor stops pointer and key events before they leave it. The test that types `"a b c"` is the proof: remove the `stopPropagation` and it becomes `"abc"`. Same class of problem as the `mantine-window` drag/focus bug.

## Immutability

`setValueAtPath` rebuilds **only the spine** down to the target and carries everything else across by reference, so `Date`, `Map`, `Set`, `RegExp`, `BigInt`, functions and React elements elsewhere in the tree keep their **identity**. A `structuredClone` or a JSON round-trip would flatten or destroy every one of them. There is a test asserting identity (`toBe`), not equality.

It throws rather than guessing when an address does not resolve: an unreachable path means the caller and the tree disagree about the shape of the data, and writing anyway would corrupt it.

The draft value lives inside the editor, never in `JsonTree`, so a keystroke does not re-render the tree. Only the address of the node being edited is lifted.

## Verification

**106 tests** (up from 90), including 13 for the path setter alone.

Driven end to end in a real browser, not only jsdom:

| check | result |
|---|---|
| typed `"Ada Lovelace"` | the space landed |
| three ArrowLefts then `X` | caret moved, `"Ada LovelXace"` — tree focus did not move |
| `Enter` | committed, editor closed, tree updated |
| change payload | `root.name: "Jamie Chen" → "Ada LovelXace"` |
| boolean click | toggled, no editor opened |
| `createdAt` (Date) | intact after two edits, never offered for editing |
| `zip` (locked by `isEditable`) | stayed read-only |
| empty value + `Enter` | rejected inline, `onChange` never fired |
| `Escape` | original restored |

`yarn test` 106/106, `yarn build`, `yarn docgen` (all six new props picked up), `yarn docs:build`.

## What is not here, and why it is not just "less work"

Renaming keys, adding, removing and reordering all need a **path format change** — escaping dots, distinguishing index from key — which changes the strings consumers receive from `onNodeClick`, see in tooltips, and **store in `expanded` arrays**. That is a major, and it is worth doing in one deliberate go rather than smuggling in here. Editing values needs none of it: with `pathSegments` alongside, a write is unambiguous even where two nodes collide on the same display path. There is a test for exactly that case.

Additive API, so this is a **minor**: `editable`, `onChange`, `editableTypes`, `isEditable`, `validate`, `editorProps`, the `valueEditor` selector, a `--json-tree-color-editable-outline` variable, and the exported types `JsonTreeChange`, `JsonTreeEditableType`, `JsonTreeNodePayload`, `JsonTreePathSegments`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added inline editing for string, number, and boolean values.
  - Supports controlled updates, validation, custom editor settings, keyboard activation, and cancellation.
  - Added immutable nested updates while preserving unrelated values.
  - Added editable demos, array root names, and styling options for editors.
  - Added public change and path-related types.

- **Documentation**
  - Expanded guidance on editing, validation, keyboard controls, accessibility, and copy-to-clipboard behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->